### PR TITLE
showing sim number if phone_account_addres returned is nullOrEmpty 

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/Context.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.media.AudioManager
 import android.net.Uri
+import android.telephony.SubscriptionManager
 import com.simplemobiletools.commons.extensions.telecomManager
 import com.simplemobiletools.dialer.helpers.Config
 import com.simplemobiletools.dialer.models.SIMAccount
@@ -40,4 +41,19 @@ fun Context.areMultipleSIMsAvailable(): Boolean {
     } catch (ignored: Exception) {
         false
     }
+}
+
+@SuppressLint("MissingPermission")
+fun Context.getSimIds(): List<String> {
+    val subscriptionManager = getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE) as SubscriptionManager
+    val availableSIMs  = subscriptionManager.activeSubscriptionInfoList
+    var simIds = mutableListOf<String>()
+    if(availableSIMs.size > 0){
+        for(subScriptionInfo in availableSIMs){
+            simIds.add(subScriptionInfo.iccId)
+        }
+    }
+    return simIds
+
+
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/Context.kt
@@ -46,14 +46,12 @@ fun Context.areMultipleSIMsAvailable(): Boolean {
 @SuppressLint("MissingPermission")
 fun Context.getSimIds(): List<String> {
     val subscriptionManager = getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE) as SubscriptionManager
-    val availableSIMs  = subscriptionManager.activeSubscriptionInfoList
-    var simIds = mutableListOf<String>()
-    if(availableSIMs.size > 0){
-        for(subScriptionInfo in availableSIMs){
-            simIds.add(subScriptionInfo.iccId)
+    val availableSIMs = subscriptionManager.activeSubscriptionInfoList
+    val simIds = mutableListOf<String>()
+    if (availableSIMs.size > 0) {
+        for (subscriptionInfo in availableSIMs) {
+            simIds.add(subscriptionInfo.iccId)
         }
     }
     return simIds
-
-
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -95,7 +95,7 @@ class RecentsHelper(private val context: Context) {
             var simID = numberToSimIDMap[accountAddress] ?: 1
 
             if(accountAddress.isNullOrEmpty()){
-                simID = 1 + simIds.indexOf(removeAllNonNumbericChars(accountId))
+                simID = 1 + simIds.indexOf(removeAllNonNumericChars(accountId))
             }
             val neighbourIDs = ArrayList<Int>()
             val recentCall = RecentCall(id, number, name, photoUri, startTS, duration, type, neighbourIDs, simID)
@@ -141,5 +141,5 @@ class RecentsHelper(private val context: Context) {
         }
     }
     
-    fun removeAllNonNumbericChars(str: String) = str.replace(Regex("[^0-9]"), "")
+    fun removeAllNonNumericChars(str: String) = str.replace(Regex("[^0-9]"), "")
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -3,7 +3,6 @@ package com.simplemobiletools.dialer.helpers
 import android.annotation.SuppressLint
 import android.content.Context
 import android.provider.CallLog.Calls
-import android.util.Log
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
 import com.simplemobiletools.commons.models.SimpleContact
@@ -38,7 +37,6 @@ class RecentsHelper(private val context: Context) {
     private fun getRecents(contacts: ArrayList<SimpleContact>, groupSubsequentCalls: Boolean, callback: (ArrayList<RecentCall>) -> Unit) {
         var recentCalls = ArrayList<RecentCall>()
         var simIds = context.getSimIds()
-
         var previousRecentCallFrom = ""
         val contactsNumbersMap = HashMap<String, String>()
         val uri = Calls.CONTENT_URI

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -100,7 +100,6 @@ class RecentsHelper(private val context: Context) {
 
             if(accountAddress.isNullOrEmpty()){
                 simID = 1 + simIds.indexOf( removeAllNonNumbericChars(accountId))
-                Log.d("__RecentsHelper", "getRecents: simid is $simID")
             }
             val neighbourIDs = ArrayList<Int>()
             val recentCall = RecentCall(id, number, name, photoUri, startTS, duration, type, neighbourIDs, simID)

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -36,10 +36,8 @@ class RecentsHelper(private val context: Context) {
     }
 
     private fun getRecents(contacts: ArrayList<SimpleContact>, groupSubsequentCalls: Boolean, callback: (ArrayList<RecentCall>) -> Unit) {
-
         var recentCalls = ArrayList<RecentCall>()
-        var simIds = mutableListOf<String>()
-        simIds.addAll(context.getSimIds())
+        var simIds = context.getSimIds()
 
         var previousRecentCallFrom = ""
         val contactsNumbersMap = HashMap<String, String>()
@@ -52,8 +50,8 @@ class RecentsHelper(private val context: Context) {
             Calls.DATE,
             Calls.DURATION,
             Calls.TYPE,
-            "phone_account_address",
-            Calls.PHONE_ACCOUNT_ID
+            Calls.PHONE_ACCOUNT_ID,
+            "phone_account_address"
         )
 
         val numberToSimIDMap = HashMap<String, Int>()
@@ -94,12 +92,12 @@ class RecentsHelper(private val context: Context) {
             val startTS = (cursor.getLongValue(Calls.DATE) / 1000L).toInt()
             val duration = cursor.getIntValue(Calls.DURATION)
             val type = cursor.getIntValue(Calls.TYPE)
-            val accountAddress:String? = cursor.getStringValue("phone_account_address")
+            val accountAddress = cursor.getStringValue("phone_account_address")
             val accountId = cursor.getStringValue(Calls.PHONE_ACCOUNT_ID)
             var simID = numberToSimIDMap[accountAddress] ?: 1
 
             if(accountAddress.isNullOrEmpty()){
-                simID = 1 + simIds.indexOf( removeAllNonNumbericChars(accountId))
+                simID = 1 + simIds.indexOf(removeAllNonNumbericChars(accountId))
             }
             val neighbourIDs = ArrayList<Int>()
             val recentCall = RecentCall(id, number, name, photoUri, startTS, duration, type, neighbourIDs, simID)
@@ -144,8 +142,6 @@ class RecentsHelper(private val context: Context) {
             }
         }
     }
-    fun removeAllNonNumbericChars(str:String): String {
-
-        return str.replace(Regex("[^0-9]"), "")
-    }
+    
+    fun removeAllNonNumbericChars(str: String) = str.replace(Regex("[^0-9]"), "")
 }

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -22,7 +22,6 @@
     <string name="dialer">Telefon</string>
     <string name="accept">Přijmout</string>
     <string name="decline">Odmítnout</string>
-    <string name="Neznámý volající">Unknown Caller</string>
     <string name="is_calling">Volání…</string>
     <string name="dialing">Vytáčení…</string>
     <string name="call_ended">Hovor ukončen</string>


### PR DESCRIPTION
- While running the app on Samsung M21 the Sim used to used to place or receive the call was always showing as 2 in call history tab.  

 **RecentsHelper.kt** 
` val accountAddress = cursor.getStringValue("phone_account_address")`
accountAddress returned was **always empty** .

- So I used 

          `  val accountId = cursor.getStringValue(Calls.PHONE_ACCOUNT_ID)`

- To get accountId and checked if that accountId is existing in the current simIdsList of the phone.

- simIdsList contains **iccId** of the sim cards in order.

- If the id contains in the list then index+1 is the sim used to place or receive the call.
