### PR TITLE
Added call confirmation to recents and favorites

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/dialogs/CallConfirmationDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/dialogs/CallConfirmationDialog.kt
@@ -1,0 +1,30 @@
+package com.simplemobiletools.dialer.dialogs
+
+import androidx.appcompat.app.AlertDialog
+import com.simplemobiletools.commons.activities.BaseSimpleActivity
+import com.simplemobiletools.commons.extensions.applyColorFilter
+import com.simplemobiletools.commons.extensions.setupDialogStuff
+import com.simplemobiletools.dialer.R
+import com.simplemobiletools.dialer.extensions.config
+import kotlinx.android.synthetic.main.dialog_call_confirmation.view.*
+
+class CallConfirmationDialog(val activity: BaseSimpleActivity, val callee: String, private val callback: () -> Unit) {
+    private var view = activity.layoutInflater.inflate(R.layout.dialog_call_confirmation, null)
+
+    init {
+        view.call_confirm_phone.applyColorFilter(activity.config.textColor)
+        AlertDialog.Builder(activity)
+            .setNegativeButton(R.string.cancel, null)
+            .create().apply {
+                val title = String.format(activity.getString(R.string.call_person), callee)
+                activity.setupDialogStuff(view, this, titleText = title) {
+                    view.call_confirm_phone.apply {
+                        setOnClickListener {
+                            callback.invoke()
+                            dismiss()
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/FavoritesFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/FavoritesFragment.kt
@@ -14,6 +14,7 @@ import com.simplemobiletools.commons.models.SimpleContact
 import com.simplemobiletools.dialer.R
 import com.simplemobiletools.dialer.activities.SimpleActivity
 import com.simplemobiletools.dialer.adapters.ContactsAdapter
+import com.simplemobiletools.dialer.dialogs.CallConfirmationDialog
 import com.simplemobiletools.dialer.interfaces.RefreshItemsListener
 import kotlinx.android.synthetic.main.fragment_letters_layout.view.*
 import java.util.*
@@ -74,7 +75,10 @@ class FavoritesFragment(context: Context, attributeSet: AttributeSet) : MyViewPa
                 ContactsAdapter(activity as SimpleActivity, contacts, fragment_list, this, showDeleteButton = false) {
                     val phoneNumbers = (it as SimpleContact).phoneNumbers
                     if (phoneNumbers.size <= 1) {
-                        activity?.launchCallIntent(it.phoneNumbers.first())
+                        val phoneNumber = it.phoneNumbers.first()
+                        CallConfirmationDialog(activity as SimpleActivity, phoneNumber) {
+                            activity?.launchCallIntent(phoneNumber)
+                        }
                     } else {
                         val items = ArrayList<RadioItem>()
                         phoneNumbers.forEachIndexed { index, phoneNumber ->

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/RecentsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/RecentsFragment.kt
@@ -9,6 +9,7 @@ import com.simplemobiletools.commons.helpers.SimpleContactsHelper
 import com.simplemobiletools.dialer.R
 import com.simplemobiletools.dialer.activities.SimpleActivity
 import com.simplemobiletools.dialer.adapters.RecentCallsAdapter
+import com.simplemobiletools.dialer.dialogs.CallConfirmationDialog
 import com.simplemobiletools.dialer.extensions.config
 import com.simplemobiletools.dialer.helpers.RecentsHelper
 import com.simplemobiletools.dialer.interfaces.RefreshItemsListener
@@ -90,7 +91,10 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
             val currAdapter = recents_list.adapter
             if (currAdapter == null) {
                 RecentCallsAdapter(activity as SimpleActivity, recents, recents_list, this) {
-                    activity?.launchCallIntent((it as RecentCall).phoneNumber)
+                    val phoneNumber = (it as RecentCall).phoneNumber
+                    CallConfirmationDialog(activity as SimpleActivity, phoneNumber) {
+                        activity?.launchCallIntent(phoneNumber)
+                    }
                 }.apply {
                     recents_list.adapter = this
                 }

--- a/app/src/main/res/layout/dialog_call_confirmation.xml
+++ b/app/src/main/res/layout/dialog_call_confirmation.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dialog_holder"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="@dimen/activity_margin">
+
+    <ImageView
+        android:id="@+id/call_confirm_phone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:padding="@dimen/activity_margin"
+        android:src="@drawable/ic_phone_vector"/>
+
+</RelativeLayout>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Poslat SMS</string>
     <string name="show_grouped_calls">Zobrazit seskupené hovory</string>
     <string name="clear_call_history">Vymazat historii hovorů</string>
+    <string name="call_person">Zavolat %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Číselník</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Sende SMS</string>
     <string name="show_grouped_calls">Zeige gruppierte Anrufe</string>
     <string name="clear_call_history">Anrufliste löschen</string>
+    <string name="call_person">%s anrufen</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Wählpad</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Αποστολή SMS</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">Κλήση %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Πληκτρολόγιο κλήσης</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Enviar SMS</string>
     <string name="show_grouped_calls">Mostrar llamadas agrupadas</string>
     <string name="clear_call_history">Borrar historial de llamadas</string>
+    <string name="call_person">Llamar a %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Teclado de marcado</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Lähetä tekstiviesti</string>
     <string name="show_grouped_calls">Näytä ryhmitetyt puhelut</string>
     <string name="clear_call_history">Tyhjennä puheluhistoria</string>
+    <string name="call_person">Soita %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Numerovalitsin</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -12,8 +12,9 @@
     <string name="remove_confirmation">Êtes-vous sûr de vouloir effacer de l\'historique les éléments sélectionnés ?</string>
     <string name="clear_history_confirmation">Êtes-vous sûr de vouloir supprimer votre historique d\'appel ?</string>
     <string name="send_sms">Envoyer un SMS</string>
-    <string name="show_grouped_calls">Afficher les appels groupés/string>
-    <string name="clear_call_history">Nettoyer l\'historique d'appel</string>
+    <string name="show_grouped_calls">Afficher les appels groupés</string>
+    <string name="clear_call_history">Nettoyer l\'historique d\'appel</string>
+    <string name="call_person">Appeler %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Pavé numérique</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Enviar SMS</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">Call %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Marcador</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Kirim SMS</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">Panggil %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Tombol nomor</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Invia SMS</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">Chiama %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Compositore numerico</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">ショートメール送信</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">%sに発信</string>
 
     <!-- Dialpad -->
     <string name="dialpad">ダイヤルパッド</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">SMS അയയ്‌ക്കുക</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">വിളിക്കുക %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">ഡയൽപാഡ്</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">SMS sturen</string>
     <string name="show_grouped_calls">Gegroepeerde gesprekken tonen</string>
     <string name="clear_call_history">Oproepgeschiedenis wissen</string>
+    <string name="call_person">%s bellen</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Telefoonkiezer</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Wyślij SMS-a</string>
     <string name="show_grouped_calls">Pokaż zgrupowane połączenia</string>
     <string name="clear_call_history">Wyczyść historię połączeń</string>
+    <string name="call_person">Zadzwoń do: %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Panel wybierania</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Enviar SMS</string>
     <string name="show_grouped_calls">Mostrar chamadas em grupo</string>
     <string name="clear_call_history">Limpar registo de chamadas</string>
+    <string name="call_person">Ligar a %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Marcador</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Отправить SMS</string>
     <string name="show_grouped_calls">Сгруппировать вызовы</string>
     <string name="clear_call_history">Очистить историю вызовов</string>
+    <string name="call_person">Вызов %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Номеронабиратель</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Odoslať SMS</string>
     <string name="show_grouped_calls">Zobraziť zoskupené volania</string>
     <string name="clear_call_history">Vymazať históriu hovorov</string>
+    <string name="call_person">Zavolať %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Číselník</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Skicka sms</string>
     <string name="show_grouped_calls">Visa grupperade samtal</string>
     <string name="clear_call_history">Rensa samtalshistorik</string>
+    <string name="call_person">Ring %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Knappsats</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">SMS gönder</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">%s kişisini ara</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Tuş takımı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Надіслати SMS</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">Телефонувати %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Dialpad</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Send SMS</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">打电话给 %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">拨号盘</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="send_sms">Send SMS</string>
     <string name="show_grouped_calls">Show grouped calls</string>
     <string name="clear_call_history">Clear call history</string>
+    <string name="call_person">Call %s</string>
 
     <!-- Dialpad -->
     <string name="dialpad">Dialpad</string>


### PR DESCRIPTION
Hi,

Regarding the #9 issue and the problem of dialing by accident, I decided to propose the solution just as described by me in the last comment. I've added confirmation dialog before calling (in recents and favorites) exactly the same as is in Simple Contacts app. 

I've copied the code from Simple Contacts, so I assume that maybe the better place for it would be Commons, but unfortunately I don't have enough knowledge about Android tooling and didn't know how to add it there to be able to test it locally. I hope it's not a problem for you and the refactoring can be done later. Even I can try to do it, but I'd like to know first if the solution is ok for you.

Also, translations of the phrase are copied from Simple Contacts app. Only "ga" was missing, so I've inserted an English phrase. 