### PR TITLE
Add settings option to launch dialpad by default

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
@@ -26,6 +26,7 @@ import com.simplemobiletools.dialer.R
 import com.simplemobiletools.dialer.adapters.ViewPagerAdapter
 import com.simplemobiletools.dialer.extensions.config
 import com.simplemobiletools.dialer.fragments.MyViewPagerFragment
+import com.simplemobiletools.dialer.helpers.OPEN_DIAL_PAD_AT_LAUNCH
 import com.simplemobiletools.dialer.helpers.RecentsHelper
 import com.simplemobiletools.dialer.helpers.tabsList
 import kotlinx.android.synthetic.main.activity_main.*
@@ -36,6 +37,7 @@ import java.util.*
 
 class MainActivity : SimpleActivity() {
     private var isSearchOpen = false
+    private var launchedDialer = false
     private var searchMenuItem: MenuItem? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,11 +46,18 @@ class MainActivity : SimpleActivity() {
         appLaunched(BuildConfig.APPLICATION_ID)
         setupTabColors()
 
+        launchedDialer = savedInstanceState?.getBoolean(OPEN_DIAL_PAD_AT_LAUNCH) ?: false
+
         if (isDefaultDialer()) {
             checkContactPermissions()
         } else {
             launchSetDefaultDialerIntent()
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(OPEN_DIAL_PAD_AT_LAUNCH, launchedDialer)
     }
 
     override fun onResume() {
@@ -272,6 +281,11 @@ class MainActivity : SimpleActivity() {
 
         main_dialpad_button.setOnClickListener {
             launchDialpad()
+        }
+
+        if(config.openDialPadAtLaunch && !launchedDialer){
+            launchDialpad()
+            launchedDialer = true
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
@@ -283,7 +283,7 @@ class MainActivity : SimpleActivity() {
             launchDialpad()
         }
 
-        if(config.openDialPadAtLaunch && !launchedDialer){
+        if (config.openDialPadAtLaunch && !launchedDialer) {
             launchDialpad()
             launchedDialer = true
         }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/SettingsActivity.kt
@@ -33,6 +33,7 @@ class SettingsActivity : SimpleActivity() {
         setupChangeDateTimeFormat()
         setupFontSize()
         setupDefaultTab()
+        setupDialPadOpen()
         setupGroupSubsequentCalls()
         setupStartNameWithSurname()
         setupShowCallConfirmation()
@@ -132,6 +133,14 @@ class SettingsActivity : SimpleActivity() {
         TAB_CALL_HISTORY -> R.string.call_history_tab
         else -> R.string.last_used_tab
     })
+
+    private fun setupDialPadOpen() {
+        settings_open_dialpad_at_launch.isChecked = config.openDialPadAtLaunch
+        settings_open_dialpad_at_launch_holder.setOnClickListener {
+            settings_open_dialpad_at_launch.toggle()
+            config.openDialPadAtLaunch = settings_open_dialpad_at_launch.isChecked
+        }
+    }
 
     private fun setupGroupSubsequentCalls() {
         settings_group_subsequent_calls.isChecked = config.groupSubsequentCalls

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Config.kt
@@ -43,4 +43,8 @@ class Config(context: Context) : BaseConfig(context) {
     var groupSubsequentCalls: Boolean
         get() = prefs.getBoolean(GROUP_SUBSEQUENT_CALLS, true)
         set(groupSubsequentCalls) = prefs.edit().putBoolean(GROUP_SUBSEQUENT_CALLS, groupSubsequentCalls).apply()
+
+    var openDialPadAtLaunch: Boolean
+        get() = prefs.getBoolean(OPEN_DIAL_PAD_AT_LAUNCH, false)
+        set(openDialPad) = prefs.edit().putBoolean(OPEN_DIAL_PAD_AT_LAUNCH, openDialPad).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
@@ -4,6 +4,7 @@ package com.simplemobiletools.dialer.helpers
 const val SPEED_DIAL = "speed_dial"
 const val REMEMBER_SIM_PREFIX = "remember_sim_"
 const val GROUP_SUBSEQUENT_CALLS = "group_subsequent_calls"
+const val OPEN_DIAL_PAD_AT_LAUNCH = "open_dial_pad_at_launch"
 
 const val CONTACTS_TAB_MASK = 1
 const val FAVORITES_TAB_MASK = 2

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -204,6 +204,29 @@
         </RelativeLayout>
 
         <RelativeLayout
+            android:id="@+id/settings_open_dialpad_at_launch_holder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/medium_margin"
+            android:background="?attr/selectableItemBackground"
+            android:paddingStart="@dimen/normal_margin"
+            android:paddingTop="@dimen/activity_margin"
+            android:paddingEnd="@dimen/normal_margin"
+            android:paddingBottom="@dimen/activity_margin">
+
+            <com.simplemobiletools.commons.views.MySwitchCompat
+                android:id="@+id/settings_open_dialpad_at_launch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:clickable="false"
+                android:paddingStart="@dimen/medium_margin"
+                android:text="@string/open_dialpad_by_default"
+                app:switchPadding="@dimen/medium_margin" />
+
+        </RelativeLayout>
+
+        <RelativeLayout
             android:id="@+id/settings_group_subsequent_calls_holder"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Seskupte další hovory se stejným číslem v protokolu hovorů</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">In der Anrufliste aufeinanderfolgende Anrufe mit derselben Nummer gruppieren</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Ομαδοποίηση των επόμενων κλήσεων του ίδιου αριθμού στο αρχείο καταγραφής κλήσεων</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Agrupar llamadas subsecuentes con el mísmo número en el registro de llamadas</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Ryhmitä saman numeron peräkkäiset puhelut puheluhistoriassa</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Regrouper les appels suivants avec le même numéro dans le journal des appels</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit :</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit :</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Agrupar, no rexisto, as chamadas para o mesmo contacto</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Kelompokkan panggilan berikutnya dengan nomor yang sama di log panggilan</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Raggruppa chiamate successive con lo stesso numero nel registro delle chiamate</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Simple Dialer</string>
     <string name="app_launcher_name">Telefono</string>
-    <string name="default_phone_app_prompt">Per favore, rendi l'app la predefinita per le chiamate</string>
+    <string name="default_phone_app_prompt">Per favore, rendi l\'app la predefinita per le chiamate</string>
 
     <!-- Contacts -->
     <string name="could_not_access_contacts">Impossibile accedere ai contatti</string>
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">後続の通話をコールログの同じ番号でグループ化する</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -67,7 +68,6 @@
         <b> Reddit:</b>
          https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -67,6 +67,7 @@
         <b> Reddit:</b>
          https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -69,6 +69,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -37,8 +37,10 @@
     <string name="speed_dial">സ്പീഡ് ഡയൽ</string>
     <string name="manage_speed_dial">സ്പീഡ് ഡയൽ നിയന്ത്രിക്കുക</string>
     <string name="speed_dial_label">കോൺ‌ടാക്റ്റ് നൽകുന്നതിന് ഒരു നമ്പറിൽ ക്ലിക്കുചെയ്യുക. ഡയലറിൽ നൽകിയ നമ്പർ ദീർഘനേരം അമർത്തിയാൽ, നിങ്ങൾ നൽകിയ കോൺടാക്റ്റിനെ വേഗത്തിൽ വിളിക്കാം. </string>
+
     <!-- Settings -->
     <string name="group_subsequent_calls">കോൾ ലോഗിൽ അതേ നമ്പറുള്ള കോളുകൾ ഗ്രൂപ്പുചെയ്യുക</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -69,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Oproepgeschiedenis: opeenvolgende items van hetzelfde nummer groeperen</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Grupuj kolejne połączenia z tym samym numerem w rejestrze połączeń</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Agrupar, no registo, as chamadas para o mesmo contacto</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Группировать последующие вызовы с тем же номером в журнале вызовов</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -40,7 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Zoskupiť susedné volania s rovnakým číslom v histórií volaní</string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="open_dialpad_by_default">Otvoriť číselník po spustení apky</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Zoskupiť susedné volania s rovnakým číslom v histórií volaní</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Gruppera samtal till och från samma nummer i samtalshistoriken</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Arama kaydında aynı numaraya sahip sonraki aramaları gruplandır</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Bazı dizeleri bulamadınız mı? Burada daha fazlası var:

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Bazı dizeleri bulamadınız mı? Burada daha fazlası var:

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Group subsequent calls with the same number at the call log</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">在通话记录中将同一号码的后续呼叫合并为一组</string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -70,7 +71,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Group subsequent calls with the same number at the call log</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
     <string name="app_title">Simple Dialer - Manage your phone calls easily</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
 
     <!-- Settings -->
     <string name="group_subsequent_calls">Group subsequent calls with the same number at the call log</string>
-
+    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
     <string name="app_title">Simple Dialer - Manage your phone calls easily</string>
@@ -70,7 +70,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
 
     <!--
         Haven't found some strings? There's more at


### PR DESCRIPTION
**Notes**
- add a settings option to launch dialpad by default
- also account for process death, in `MainActivity`, persist the state of whether the dialer had been launched by default
- fix missing escape on apostrophe in the Italian (-it) string resource
- should address this [request](https://github.com/SimpleMobileTools/Simple-Dialer/issues/110)

**Screenshot**

<img src="https://user-images.githubusercontent.com/25648077/129454866-8e956638-2908-4e5d-ae8e-0c5fe4e091ff.gif"  alt="Screenshot" width="302">

