### PR TITLE
Feat/import export blocked contacts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:a6a0349426'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:e3c531cbd1'
     implementation 'com.github.tibbi:IndicatorFastScroll:c3de1d040a'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
     <uses-permission android:name="android.telecom.action.CONFIGURE_PHONE_ACCOUNT" />
 
     <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+
+    <uses-permission
         android:name="android.permission.USE_FINGERPRINT"
         tools:node="remove" />
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Simple Dialer</string>
     <string name="app_launcher_name">Telefono</string>
-    <string name="default_phone_app_prompt">Per favore, rendi l'app la predefinita per le chiamate</string>
+    <string name="default_phone_app_prompt">Per favore, rendi l\'app la predefinita per le chiamate</string>
 
     <!-- Contacts -->
     <string name="could_not_access_contacts">Impossibile accedere ai contatti</string>


### PR DESCRIPTION
**Notes**
- Add `WRITE_EXTERNAL_STORAGE` permission required for importing/exporting blocked contacts
- Update dependency for commons library
- related to this [issue](https://github.com/SimpleMobileTools/Simple-Dialer/issues/113) and [this PR](https://github.com/SimpleMobileTools/Simple-Commons/pull/1125)
