### PR TITLE
Prevent keyboard from showing up at the dialpad

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -100,6 +100,7 @@
         <activity
             android:name=".activities.DialpadActivity"
             android:label="@string/dialpad"
+            android:windowSoftInputMode="stateHidden"
             android:parentActivityName=".activities.MainActivity">
 
             <intent-filter>


### PR DESCRIPTION
**Notes**
- Add windowSoftInputMode = stateHidden in AndroidManifest to prevent keyboard from showing in `DialpadActivity`
- should address [this issue](https://github.com/SimpleMobileTools/Simple-Dialer/issues/220)

**Screenshot of issue**
<figure>
<img src="https://user-images.githubusercontent.com/25648077/130880637-e3685037-dfb4-4673-9272-23b2ebcc56f2.gif" alt="Screenshot of issue" width="302">
<figcaption align = "center">Keyboard shows up when the activity is resumed and the edit text has focus</figcaption>
</figure>

<br>
<br>
<br>
<br>

**Screenshot of fix**
<figure>
<img src="https://user-images.githubusercontent.com/25648077/130880581-167df5a2-cc69-4159-a410-231d758a45ec.gif" alt="Screenshot of issue" width="302">
<figcaption align = "center">Keyboard does not show up when the activity is resumed</figcaption>
</figure>
