### PR TITLE
Feat/ handle back press for calls

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/App.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/App.kt
@@ -2,8 +2,10 @@ package com.simplemobiletools.dialer
 
 import android.app.Application
 import com.simplemobiletools.commons.extensions.checkUseEnglish
+import com.simplemobiletools.dialer.helpers.CallDurationHelper
 
 class App : Application() {
+    val callDurationHelper by lazy { CallDurationHelper() }
     override fun onCreate() {
         super.onCreate()
         checkUseEnglish()

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
@@ -44,7 +44,7 @@ class CallActivity : SimpleActivity() {
     private var proximityWakeLock: PowerManager.WakeLock? = null
     private var callDuration = 0
     private val callContactAvatarHelper by lazy { CallContactAvatarHelper(this) }
-    private val callDurationHelper by lazy {  (application as App).callDurationHelper }
+    private val callDurationHelper by lazy { (application as App).callDurationHelper }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         supportActionBar?.hide()

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
@@ -70,8 +70,6 @@ class CallActivity : SimpleActivity() {
         if (proximityWakeLock?.isHeld == true) {
             proximityWakeLock!!.release()
         }
-
-        endCall()
     }
 
     override fun onBackPressed() {
@@ -82,7 +80,8 @@ class CallActivity : SimpleActivity() {
             super.onBackPressed()
         }
 
-        if (CallManager.getState() == Call.STATE_DIALING) {
+        val callState = CallManager.getState()
+        if (callState == Call.STATE_CONNECTING || callState == Call.STATE_DIALING) {
             endCall()
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
@@ -22,7 +22,6 @@ import com.simplemobiletools.dialer.extensions.config
 import com.simplemobiletools.dialer.extensions.getHandleToUse
 import com.simplemobiletools.dialer.helpers.CallContactAvatarHelper
 import com.simplemobiletools.dialer.helpers.CallManager
-import com.simplemobiletools.dialer.helpers.CallNotificationManager
 import com.simplemobiletools.dialer.models.CallContact
 import java.util.Timer
 import java.util.TimerTask
@@ -38,7 +37,6 @@ class CallActivity : SimpleActivity() {
     private var proximityWakeLock: PowerManager.WakeLock? = null
     private var callTimer = Timer()
     private val callContactAvatarHelper by lazy { CallContactAvatarHelper(this) }
-    private val callNotificationManager by lazy { CallNotificationManager(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         supportActionBar?.hide()
@@ -54,7 +52,6 @@ class CallActivity : SimpleActivity() {
             callContact = contact
             val avatar = callContactAvatarHelper.getCallContactAvatar(contact)
             runOnUiThread {
-                callNotificationManager.setupNotification()
                 updateOtherPersonsInfo(avatar)
                 checkCalledSIMCard()
             }
@@ -68,7 +65,6 @@ class CallActivity : SimpleActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        callNotificationManager.cancelNotification()
         CallManager.unregisterCallback(callCallback)
         callTimer.cancel()
         if (proximityWakeLock?.isHeld == true) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.dialer.activities
 import android.annotation.SuppressLint
 import android.app.KeyguardManager
 import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
 import android.media.AudioManager
 import android.os.Bundle
@@ -29,6 +30,14 @@ import kotlinx.android.synthetic.main.activity_call.*
 import kotlinx.android.synthetic.main.dialpad.*
 
 class CallActivity : SimpleActivity() {
+    companion object {
+        fun getStartIntent(context: Context): Intent {
+            val openAppIntent = Intent(context, CallActivity::class.java)
+            openAppIntent.flags = Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT or Intent.FLAG_ACTIVITY_NEW_TASK
+            return openAppIntent
+        }
+    }
+
     private var isSpeakerOn = false
     private var isMicrophoneOn = true
     private var isCallEnded = false

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallContactAvatarHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallContactAvatarHelper.kt
@@ -1,0 +1,49 @@
+package com.simplemobiletools.dialer.helpers
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.*
+import android.net.Uri
+import android.provider.MediaStore
+import android.util.Size
+import com.simplemobiletools.commons.helpers.isQPlus
+import com.simplemobiletools.dialer.R
+import com.simplemobiletools.dialer.models.CallContact
+
+class CallContactAvatarHelper(private val context: Context) {
+    @SuppressLint("NewApi")
+    fun getCallContactAvatar(callContact: CallContact?): Bitmap? {
+        var bitmap: Bitmap? = null
+        if (callContact?.photoUri?.isNotEmpty() == true) {
+            val photoUri = Uri.parse(callContact.photoUri)
+            try {
+                val contentResolver = context.contentResolver
+                bitmap = if (isQPlus()) {
+                    val tmbSize = context.resources.getDimension(R.dimen.list_avatar_size).toInt()
+                    contentResolver.loadThumbnail(photoUri, Size(tmbSize, tmbSize), null)
+                } else {
+                    MediaStore.Images.Media.getBitmap(contentResolver, photoUri)
+                }
+                bitmap = getCircularBitmap(bitmap!!)
+            } catch (ignored: Exception) {
+                return null
+            }
+        }
+        return bitmap
+    }
+
+    fun getCircularBitmap(bitmap: Bitmap): Bitmap {
+        val output = Bitmap.createBitmap(bitmap.width, bitmap.width, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(output)
+        val paint = Paint()
+        val rect = Rect(0, 0, bitmap.width, bitmap.height)
+        val radius = bitmap.width / 2.toFloat()
+
+        paint.isAntiAlias = true
+        canvas.drawARGB(0, 0, 0, 0)
+        canvas.drawCircle(radius, radius, radius, paint)
+        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+        canvas.drawBitmap(bitmap, rect, rect, paint)
+        return output
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallDurationHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallDurationHelper.kt
@@ -1,0 +1,32 @@
+package com.simplemobiletools.dialer.helpers
+
+import java.util.Timer
+import java.util.TimerTask
+
+class CallDurationHelper {
+    private var callTimer = Timer()
+    private var callDuration = 0
+    private var callback: ((durationSecs: Int) -> Unit)? = null
+
+    fun onDurationChange(callback: (durationSecs: Int) -> Unit) {
+        this.callback = callback
+    }
+
+    fun start() {
+        try {
+            callTimer.scheduleAtFixedRate(getTimerUpdateTask(), 1000, 1000)
+        } catch (ignored: Exception) {
+        }
+    }
+
+    fun cancel() {
+        callTimer.cancel()
+    }
+
+    private fun getTimerUpdateTask() = object : TimerTask() {
+        override fun run() {
+            callDuration++
+            callback?.invoke(callDuration)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallDurationHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallDurationHelper.kt
@@ -4,7 +4,7 @@ import java.util.Timer
 import java.util.TimerTask
 
 class CallDurationHelper {
-    private var callTimer = Timer()
+    private var callTimer: Timer? = null
     private var callDuration = 0
     private var callback: ((durationSecs: Int) -> Unit)? = null
 
@@ -14,13 +14,15 @@ class CallDurationHelper {
 
     fun start() {
         try {
-            callTimer.scheduleAtFixedRate(getTimerUpdateTask(), 1000, 1000)
+            callDuration = 0
+            callTimer = Timer()
+            callTimer?.scheduleAtFixedRate(getTimerUpdateTask(), 1000, 1000)
         } catch (ignored: Exception) {
         }
     }
 
     fun cancel() {
-        callTimer.cancel()
+        callTimer?.cancel()
     }
 
     private fun getTimerUpdateTask() = object : TimerTask() {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallNotificationManager.kt
@@ -1,0 +1,96 @@
+package com.simplemobiletools.dialer.helpers
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.telecom.Call
+import android.widget.RemoteViews
+import androidx.core.app.NotificationCompat
+import com.simplemobiletools.commons.extensions.notificationManager
+import com.simplemobiletools.commons.extensions.setText
+import com.simplemobiletools.commons.extensions.setVisibleIf
+import com.simplemobiletools.commons.helpers.isOreoPlus
+import com.simplemobiletools.dialer.R
+import com.simplemobiletools.dialer.activities.CallActivity
+import com.simplemobiletools.dialer.receivers.CallActionReceiver
+
+class CallNotificationManager(private val context: Context) {
+    private val CALL_NOTIFICATION_ID = 1
+    private val notificationManager = context.notificationManager
+    private val callContactAvatarHelper = CallContactAvatarHelper(context)
+
+    @SuppressLint("NewApi")
+    fun setupNotification() {
+        CallManager.getCallContact(context.applicationContext) { callContact ->
+            val callContactAvatar = callContactAvatarHelper.getCallContactAvatar(callContact)
+            val callState = CallManager.getState()
+            val channelId = "simple_dialer_call"
+            if (isOreoPlus()) {
+                val importance = NotificationManager.IMPORTANCE_DEFAULT
+                val name = "call_notification_channel"
+
+                NotificationChannel(channelId, name, importance).apply {
+                    setSound(null, null)
+                    notificationManager.createNotificationChannel(this)
+                }
+            }
+
+            val openAppIntent = Intent(context, CallActivity::class.java)
+            openAppIntent.flags = Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT
+            val openAppPendingIntent = PendingIntent.getActivity(context, 0, openAppIntent, 0)
+
+            val acceptCallIntent = Intent(context, CallActionReceiver::class.java)
+            acceptCallIntent.action = ACCEPT_CALL
+            val acceptPendingIntent = PendingIntent.getBroadcast(context, 0, acceptCallIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+
+            val declineCallIntent = Intent(context, CallActionReceiver::class.java)
+            declineCallIntent.action = DECLINE_CALL
+            val declinePendingIntent = PendingIntent.getBroadcast(context, 1, declineCallIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+
+            val callerName = if (callContact != null && callContact.name.isNotEmpty()) callContact.name else context.getString(R.string.unknown_caller)
+            val contentTextId = when (callState) {
+                Call.STATE_RINGING -> R.string.is_calling
+                Call.STATE_DIALING -> R.string.dialing
+                Call.STATE_DISCONNECTED -> R.string.call_ended
+                Call.STATE_DISCONNECTING -> R.string.call_ending
+                else -> R.string.ongoing_call
+            }
+
+            val collapsedView = RemoteViews(context.packageName, R.layout.call_notification).apply {
+                setText(R.id.notification_caller_name, callerName)
+                setText(R.id.notification_call_status, context.getString(contentTextId))
+                setVisibleIf(R.id.notification_accept_call, callState == Call.STATE_RINGING)
+
+                setOnClickPendingIntent(R.id.notification_decline_call, declinePendingIntent)
+                setOnClickPendingIntent(R.id.notification_accept_call, acceptPendingIntent)
+
+                if (callContactAvatar != null) {
+                    setImageViewBitmap(R.id.notification_thumbnail, callContactAvatarHelper.getCircularBitmap(callContactAvatar))
+                }
+            }
+
+            val builder = NotificationCompat.Builder(context, channelId)
+                .setSmallIcon(R.drawable.ic_phone_vector)
+                .setContentIntent(openAppPendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setCategory(Notification.CATEGORY_CALL)
+                .setCustomContentView(collapsedView)
+                .setOngoing(true)
+                .setSound(null)
+                .setUsesChronometer(callState == Call.STATE_ACTIVE)
+                .setChannelId(channelId)
+                .setStyle(NotificationCompat.DecoratedCustomViewStyle())
+
+            val notification = builder.build()
+            notificationManager.notify(CALL_NOTIFICATION_ID, notification)
+        }
+    }
+
+    fun cancelNotification() {
+        notificationManager.cancel(CALL_NOTIFICATION_ID)
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallNotificationManager.kt
@@ -20,6 +20,8 @@ import com.simplemobiletools.dialer.receivers.CallActionReceiver
 
 class CallNotificationManager(private val context: Context) {
     private val CALL_NOTIFICATION_ID = 1
+    private val ACCEPT_CALL_CODE = 0
+    private val DECLINE_CALL_CODE = 1
     private val notificationManager = context.notificationManager
     private val callContactAvatarHelper = CallContactAvatarHelper(context)
 
@@ -44,11 +46,11 @@ class CallNotificationManager(private val context: Context) {
 
             val acceptCallIntent = Intent(context, CallActionReceiver::class.java)
             acceptCallIntent.action = ACCEPT_CALL
-            val acceptPendingIntent = PendingIntent.getBroadcast(context, 0, acceptCallIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+            val acceptPendingIntent = PendingIntent.getBroadcast(context, ACCEPT_CALL_CODE, acceptCallIntent, PendingIntent.FLAG_CANCEL_CURRENT)
 
             val declineCallIntent = Intent(context, CallActionReceiver::class.java)
             declineCallIntent.action = DECLINE_CALL
-            val declinePendingIntent = PendingIntent.getBroadcast(context, 1, declineCallIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+            val declinePendingIntent = PendingIntent.getBroadcast(context, DECLINE_CALL_CODE, declineCallIntent, PendingIntent.FLAG_CANCEL_CURRENT)
 
             val callerName = if (callContact != null && callContact.name.isNotEmpty()) callContact.name else context.getString(R.string.unknown_caller)
             val contentTextId = when (callState) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallNotificationManager.kt
@@ -39,8 +39,7 @@ class CallNotificationManager(private val context: Context) {
                 }
             }
 
-            val openAppIntent = Intent(context, CallActivity::class.java)
-            openAppIntent.flags = Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT
+            val openAppIntent = CallActivity.getStartIntent(context)
             val openAppPendingIntent = PendingIntent.getActivity(context, 0, openAppIntent, 0)
 
             val acceptCallIntent = Intent(context, CallActionReceiver::class.java)

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/receivers/CallActionReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/receivers/CallActionReceiver.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.dialer.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.simplemobiletools.dialer.activities.CallActivity
 import com.simplemobiletools.dialer.helpers.ACCEPT_CALL
 import com.simplemobiletools.dialer.helpers.CallManager
 import com.simplemobiletools.dialer.helpers.DECLINE_CALL
@@ -10,7 +11,10 @@ import com.simplemobiletools.dialer.helpers.DECLINE_CALL
 class CallActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
-            ACCEPT_CALL -> CallManager.accept()
+            ACCEPT_CALL -> {
+                context.startActivity(CallActivity.getStartIntent(context))
+                CallManager.accept()
+            }
             DECLINE_CALL -> CallManager.reject()
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
@@ -1,6 +1,5 @@
 package com.simplemobiletools.dialer.services
 
-import android.content.Intent
 import android.telecom.Call
 import android.telecom.InCallService
 import com.simplemobiletools.dialer.activities.CallActivity
@@ -18,9 +17,7 @@ class CallService : InCallService() {
 
     override fun onCallAdded(call: Call) {
         super.onCallAdded(call)
-        val intent = Intent(this, CallActivity::class.java)
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivity(intent)
+        startActivity(CallActivity.getStartIntent(this))
         CallManager.call = call
         CallManager.inCallService = this
         CallManager.registerCallback(callListener)

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
@@ -9,7 +9,7 @@ import com.simplemobiletools.dialer.helpers.CallNotificationManager
 
 class CallService : InCallService() {
     private val callNotificationManager by lazy { CallNotificationManager(this) }
-    private val callDurationHelper by lazy {  (application as App).callDurationHelper }
+    private val callDurationHelper by lazy { (application as App).callDurationHelper }
 
     private val callListener = object : Call.Callback() {
         override fun onStateChanged(call: Call, state: Int) {
@@ -17,7 +17,7 @@ class CallService : InCallService() {
             callNotificationManager.setupNotification()
             if (state == Call.STATE_ACTIVE) {
                 callDurationHelper.start()
-            }else if (state == Call.STATE_DISCONNECTED || state == Call.STATE_DISCONNECTING) {
+            } else if (state == Call.STATE_DISCONNECTED || state == Call.STATE_DISCONNECTING) {
                 callDurationHelper.cancel()
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
@@ -5,8 +5,17 @@ import android.telecom.Call
 import android.telecom.InCallService
 import com.simplemobiletools.dialer.activities.CallActivity
 import com.simplemobiletools.dialer.helpers.CallManager
+import com.simplemobiletools.dialer.helpers.CallNotificationManager
 
 class CallService : InCallService() {
+    private val callNotificationManager by lazy { CallNotificationManager(this) }
+    private val callListener = object : Call.Callback() {
+        override fun onStateChanged(call: Call, state: Int) {
+            super.onStateChanged(call, state)
+            callNotificationManager.setupNotification()
+        }
+    }
+
     override fun onCallAdded(call: Call) {
         super.onCallAdded(call)
         val intent = Intent(this, CallActivity::class.java)
@@ -14,11 +23,20 @@ class CallService : InCallService() {
         startActivity(intent)
         CallManager.call = call
         CallManager.inCallService = this
+        CallManager.registerCallback(callListener)
+        callNotificationManager.setupNotification()
     }
 
     override fun onCallRemoved(call: Call) {
         super.onCallRemoved(call)
         CallManager.call = null
         CallManager.inCallService = null
+        callNotificationManager.cancelNotification()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        CallManager.registerCallback(callListener)
+        callNotificationManager.cancelNotification()
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
@@ -14,7 +14,9 @@ class CallService : InCallService() {
     private val callListener = object : Call.Callback() {
         override fun onStateChanged(call: Call, state: Int) {
             super.onStateChanged(call, state)
-            callNotificationManager.setupNotification()
+            if(state != Call.STATE_DISCONNECTED){
+                callNotificationManager.setupNotification()
+            }
             if (state == Call.STATE_ACTIVE) {
                 callDurationHelper.start()
             } else if (state == Call.STATE_DISCONNECTED || state == Call.STATE_DISCONNECTING) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
@@ -2,16 +2,24 @@ package com.simplemobiletools.dialer.services
 
 import android.telecom.Call
 import android.telecom.InCallService
+import com.simplemobiletools.dialer.App
 import com.simplemobiletools.dialer.activities.CallActivity
 import com.simplemobiletools.dialer.helpers.CallManager
 import com.simplemobiletools.dialer.helpers.CallNotificationManager
 
 class CallService : InCallService() {
     private val callNotificationManager by lazy { CallNotificationManager(this) }
+    private val callDurationHelper by lazy {  (application as App).callDurationHelper }
+
     private val callListener = object : Call.Callback() {
         override fun onStateChanged(call: Call, state: Int) {
             super.onStateChanged(call, state)
             callNotificationManager.setupNotification()
+            if (state == Call.STATE_ACTIVE) {
+                callDurationHelper.start()
+            }else if (state == Call.STATE_DISCONNECTED || state == Call.STATE_DISCONNECTING) {
+                callDurationHelper.cancel()
+            }
         }
     }
 
@@ -35,5 +43,6 @@ class CallService : InCallService() {
         super.onDestroy()
         CallManager.registerCallback(callListener)
         callNotificationManager.cancelNotification()
+        callDurationHelper.cancel()
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
@@ -14,9 +14,10 @@ class CallService : InCallService() {
     private val callListener = object : Call.Callback() {
         override fun onStateChanged(call: Call, state: Int) {
             super.onStateChanged(call, state)
-            if(state != Call.STATE_DISCONNECTED){
+            if (state != Call.STATE_DISCONNECTED) {
                 callNotificationManager.setupNotification()
             }
+
             if (state == Call.STATE_ACTIVE) {
                 callDurationHelper.start()
             } else if (state == Call.STATE_DISCONNECTED || state == Call.STATE_DISCONNECTING) {


### PR DESCRIPTION
**Notes**
- create `CallNotificationManager` to handle notifications, to ensure separation of concerns
- create helper class `CallContactAvatarHelper` to get the contact's avatar. It is needed by the `CallActivity` and `CallNotificationManager`
- remove notification handling from `CallActivity`
- handle notification in `CallService`, including adding a `Call.Callback` method to update notification when the call state changes
- in `CallActivity`, only end the call if the state is `STATE_CONNECTING` or `STATE_DIALING`
- add `CallActivity.getStartIntent` method to get the start intent for `CallActivity` and update in `CallNotificationManager` and `CallService` where the `CallActivity` is started
- in `CallActionReceiver`, start the `CallActivity` before answering the call, this is needed to ensure the correct timer duration indication of the call. 
- add `CallDurationHelper` to keep track of call duration and the same instance is accessed from the `App` class
- this should address [this issue](https://github.com/SimpleMobileTools/Simple-Dialer/issues/104)


---
**Before** | **After**
---|---
<img src="https://user-images.githubusercontent.com/25648077/133946720-f0b7d83b-927b-4d85-aa2d-d9b3512947e9.gif" width="300"> | <img src="https://user-images.githubusercontent.com/25648077/133946721-dac32ec0-1d5c-4357-87a2-5cde685ac3c3.gif" width="300">

