### PR TITLE
Make it possible to disable proximity sensor during calls

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
@@ -342,7 +342,7 @@ class CallActivity : SimpleActivity() {
     }
 
     private fun initProximitySensor() {
-        if (proximityWakeLock == null || proximityWakeLock?.isHeld == false) {
+        if (!config.disableProximitySensor && (proximityWakeLock == null || proximityWakeLock?.isHeld == false)) {
             val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
             proximityWakeLock = powerManager.newWakeLock(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK, "com.simplemobiletools.dialer.pro:wake_lock")
             proximityWakeLock!!.acquire(10 * MINUTE_SECONDS * 1000L)

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/SettingsActivity.kt
@@ -37,6 +37,7 @@ class SettingsActivity : SimpleActivity() {
         setupGroupSubsequentCalls()
         setupStartNameWithSurname()
         setupShowCallConfirmation()
+        setupDisableProximitySensor()
         updateTextColors(settings_holder)
         invalidateOptionsMenu()
     }
@@ -167,6 +168,14 @@ class SettingsActivity : SimpleActivity() {
         settings_show_call_confirmation_holder.setOnClickListener {
             settings_show_call_confirmation.toggle()
             config.showCallConfirmation = settings_show_call_confirmation.isChecked
+        }
+    }
+
+    private fun setupDisableProximitySensor() {
+        settings_disable_proximity_sensor.isChecked = config.disableProximitySensor
+        settings_disable_proximity_sensor_holder.setOnClickListener {
+            settings_disable_proximity_sensor.toggle()
+            config.disableProximitySensor = settings_disable_proximity_sensor.isChecked
         }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Config.kt
@@ -47,4 +47,8 @@ class Config(context: Context) : BaseConfig(context) {
     var openDialPadAtLaunch: Boolean
         get() = prefs.getBoolean(OPEN_DIAL_PAD_AT_LAUNCH, false)
         set(openDialPad) = prefs.edit().putBoolean(OPEN_DIAL_PAD_AT_LAUNCH, openDialPad).apply()
+
+    var disableProximitySensor: Boolean
+        get() = prefs.getBoolean(DISABLE_PROXIMITY_SENSOR, false)
+        set(disableProximitySensor) = prefs.edit().putBoolean(DISABLE_PROXIMITY_SENSOR, disableProximitySensor).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
@@ -5,6 +5,7 @@ const val SPEED_DIAL = "speed_dial"
 const val REMEMBER_SIM_PREFIX = "remember_sim_"
 const val GROUP_SUBSEQUENT_CALLS = "group_subsequent_calls"
 const val OPEN_DIAL_PAD_AT_LAUNCH = "open_dial_pad_at_launch"
+const val DISABLE_PROXIMITY_SENSOR = "disable_proximity_sensor"
 
 const val CONTACTS_TAB_MASK = 1
 const val FAVORITES_TAB_MASK = 2

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -294,5 +294,28 @@
                 app:switchPadding="@dimen/medium_margin" />
 
         </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/settings_disable_proximity_sensor_holder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="@dimen/medium_margin"
+            android:background="?attr/selectableItemBackground"
+            android:paddingStart="@dimen/normal_margin"
+            android:paddingTop="@dimen/activity_margin"
+            android:paddingEnd="@dimen/normal_margin"
+            android:paddingBottom="@dimen/activity_margin">
+
+            <com.simplemobiletools.commons.views.MySwitchCompat
+                android:id="@+id/settings_disable_proximity_sensor"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:clickable="false"
+                android:paddingStart="@dimen/medium_margin"
+                android:text="@string/disable_proximity_sensor"
+                app:switchPadding="@dimen/medium_margin" />
+
+        </RelativeLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Seskupte další hovory se stejným číslem v protokolu hovorů</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">In der Anrufliste aufeinanderfolgende Anrufe mit derselben Nummer gruppieren</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Ομαδοποίηση των επόμενων κλήσεων του ίδιου αριθμού στο αρχείο καταγραφής κλήσεων</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Agrupar llamadas subsecuentes con el mísmo número en el registro de llamadas</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Ryhmitä saman numeron peräkkäiset puhelut puheluhistoriassa</string>
     <string name="open_dialpad_by_default">Avaa numeronäppäimistö, kun sovellus avataan</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Regrouper les appels suivants avec le même numéro dans le journal des appels</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Agrupar, no rexisto, as chamadas para o mesmo contacto</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Kelompokkan panggilan berikutnya dengan nomor yang sama di log panggilan</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Raggruppa chiamate successive con lo stesso numero nel registro delle chiamate</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">後続の通話をコールログの同じ番号でグループ化する</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">കോൾ ലോഗിൽ അതേ നമ്പറുള്ള കോളുകൾ ഗ്രൂപ്പുചെയ്യുക</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Oproepgeschiedenis: opeenvolgende items van hetzelfde nummer groeperen</string>
     <string name="open_dialpad_by_default">Standaard het toetsenblok openen bij starten</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>v
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Grupuj kolejne połączenia z tym samym numerem w rejestrze połączeń</string>
     <string name="open_dialpad_by_default">Otwieraj domyślnie panel wybierania przy uruchomieniu aplikacji</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Agrupar, no registo, as chamadas para o mesmo contacto</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Группировать последующие вызовы с тем же номером в журнале вызовов</string>
     <string name="open_dialpad_by_default">По умолчанию открывать номеронабиратель при запуске приложения</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -41,7 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Zoskupiť susedné volania s rovnakým číslom v histórií volaní</string>
     <string name="open_dialpad_by_default">Otvoriť číselník po spustení apky</string>
-    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
+    <string name="disable_proximity_sensor">Vypnúť počas hovorov senzor priblíženia</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Zoskupiť susedné volania s rovnakým číslom v histórií volaní</string>
     <string name="open_dialpad_by_default">Otvoriť číselník po spustení apky</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Gruppera samtal till och från samma nummer i samtalshistoriken</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Arama kaydında aynı numaraya sahip sonraki aramaları gruplandır</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Group subsequent calls with the same number at the call log</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">在通话记录中将同一号码的后续呼叫合并为一组</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <!-- Settings -->
     <string name="group_subsequent_calls">Group subsequent calls with the same number at the call log</string>
     <string name="open_dialpad_by_default">Open the dialpad by default when the app opens</string>
+    <string name="disable_proximity_sensor">Disable proximity sensor during calls</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->


### PR DESCRIPTION
There are phones out there with broken proximity sensors that always report near, which causes every dialer app to turn off the screen unconditionally during calls. As an owner of such a phone, this has been driving me crazy.

This pull request adds a new setting to determine whether the proximity sensor is to be used. By default, it is enabled, preserving the current behaviour.