### PR TITLE
Fixed invisible tabs content after managing tabs visibility

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
@@ -68,6 +68,8 @@ class MainActivity : SimpleActivity() {
         } else {
             launchSetDefaultDialerIntent()
         }
+
+        hideTabs()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -100,7 +102,8 @@ class MainActivity : SimpleActivity() {
 
         if (!isSearchOpen) {
             if (storedShowTabs != config.showTabs) {
-                hideTabs()
+                System.exit(0)
+                return
             }
             refreshItems(true)
         }


### PR DESCRIPTION
Hi,

After upgrading Kotlin version (https://github.com/SimpleMobileTools/Simple-Dialer/commit/ec9ab4dc4b2328197c3556d2d57d5bfc9f32a0d2), tabs content were becoming invisible after changing tabs visibility, what made user to restart the app to see everything properly. Generally, it was the same bug as described in tabs original pull request: https://github.com/SimpleMobileTools/Simple-Dialer/pull/239#issuecomment-981132698.

To fix it without downgrading Kotlin again, I decided to copy the solution from Simple File Manager, where the app is restarted after changing tabs visibility.

Before:

https://user-images.githubusercontent.com/85929121/153834618-27d25720-f913-4075-a510-76cf3db25737.mp4

After:

https://user-images.githubusercontent.com/85929121/153834649-903724a4-fc71-4dac-932c-7b798ac15e8a.mp4
