### PR TITLE
Limit recent call logs to 100 

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -65,11 +65,17 @@ class RecentsHelper(private val context: Context) {
             accountIdToSimIDMap[it.handle.id] = it.id
         }
 
-        val bundle = Bundle().apply {
-            putStringArray(ContentResolver.QUERY_ARG_SORT_COLUMNS, arrayOf(Calls._ID))
-            putInt(ContentResolver.QUERY_ARG_SORT_DIRECTION, ContentResolver.QUERY_SORT_DIRECTION_DESCENDING)
+        val cursor = if (isRPlus()) {
+            val bundle = Bundle().apply {
+                putStringArray(ContentResolver.QUERY_ARG_SORT_COLUMNS, arrayOf(Calls._ID))
+                putInt(ContentResolver.QUERY_ARG_SORT_DIRECTION, ContentResolver.QUERY_SORT_DIRECTION_DESCENDING)
+            }
+
+            context.contentResolver.query(uri, projection, bundle, null)
+        } else {
+            val sortOrder = "${Calls._ID} DESC"
+            context.contentResolver.query(uri, projection, null, null, sortOrder)
         }
-        val cursor = context.contentResolver.query(uri, projection, bundle, null)
 
         val contactsWithMultipleNumbers = contacts.filter { it.phoneNumbers.size > 1 }
         val numbersToContactIDMap = HashMap<String, Int>()

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -1,9 +1,7 @@
 package com.simplemobiletools.dialer.helpers
 
 import android.annotation.SuppressLint
-import android.content.ContentResolver
 import android.content.Context
-import android.os.Bundle
 import android.provider.CallLog.Calls
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
@@ -45,10 +43,7 @@ class RecentsHelper(private val context: Context) {
         val contactsNumbersMap = HashMap<String, String>()
         val contactPhotosMap = HashMap<String, String>()
 
-        val uri = Calls.CONTENT_URI.buildUpon()
-            .appendQueryParameter(Calls.LIMIT_PARAM_KEY, QUERY_LIMIT)
-            .build()
-
+        val uri = Calls.CONTENT_URI
         val projection = arrayOf(
             Calls._ID,
             Calls.NUMBER,
@@ -65,15 +60,15 @@ class RecentsHelper(private val context: Context) {
             accountIdToSimIDMap[it.handle.id] = it.id
         }
 
-        val cursor = if (isRPlus()) {
-            val bundle = Bundle().apply {
-                putStringArray(ContentResolver.QUERY_ARG_SORT_COLUMNS, arrayOf(Calls._ID))
-                putInt(ContentResolver.QUERY_ARG_SORT_DIRECTION, ContentResolver.QUERY_SORT_DIRECTION_DESCENDING)
-            }
-
-            context.contentResolver.query(uri, projection, bundle, null)
-        } else {
+        val cursor = if (isNougatPlus()) {
+            // https://issuetracker.google.com/issues/175198972?pli=1#comment6
+            val limitedUri = uri.buildUpon()
+                .appendQueryParameter(Calls.LIMIT_PARAM_KEY, QUERY_LIMIT)
+                .build()
             val sortOrder = "${Calls._ID} DESC"
+            context.contentResolver.query(limitedUri, projection, null, null, sortOrder)
+        } else {
+            val sortOrder = "${Calls._ID} DESC LIMIT $QUERY_LIMIT"
             context.contentResolver.query(uri, projection, null, null, sortOrder)
         }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -163,6 +163,7 @@ class RecentsHelper(private val context: Context) {
                 previousRecentCallFrom = "$number$name$simID"
             } while (cursor.moveToNext())
         }
+        cursor?.close()
 
         val blockedNumbers = context.getBlockedNumbers()
         recentCalls = recentCalls.filter { !context.isNumberBlocked(it.phoneNumber, blockedNumbers) }.toMutableList() as ArrayList<RecentCall>

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -13,7 +13,7 @@ import com.simplemobiletools.dialer.models.RecentCall
 
 class RecentsHelper(private val context: Context) {
     private val COMPARABLE_PHONE_NUMBER_LENGTH = 9
-    private val QUERY_LIMIT = "100"
+    private val QUERY_LIMIT = "200"
 
     @SuppressLint("MissingPermission")
     fun getRecentCalls(groupSubsequentCalls: Boolean, callback: (ArrayList<RecentCall>) -> Unit) {


### PR DESCRIPTION
As suggested [here](https://issuetracker.google.com/issues/175198972?pli=1#comment6), `Calls.LIMIT_PARAM_KEY` is the correct way to do this.