### PR TITLE
Implement setting toggles for vibrations and beeps at dialpad

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.telecom.action.CONFIGURE_PHONE_ACCOUNT" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
@@ -364,7 +364,7 @@ class CallActivity : SimpleActivity() {
     }
 
     private fun dialpadPressed(char: Char) {
-        CallManager.keypad(char)
+        CallManager.keypad(this, char)
         dialpad_input.addCharacter(char)
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -19,6 +19,7 @@ import com.simplemobiletools.commons.models.SimpleContact
 import com.simplemobiletools.dialer.R
 import com.simplemobiletools.dialer.adapters.ContactsAdapter
 import com.simplemobiletools.dialer.extensions.*
+import com.simplemobiletools.dialer.helpers.ToneGeneratorHelper
 import com.simplemobiletools.dialer.models.SpeedDial
 import kotlinx.android.synthetic.main.activity_dialpad.*
 import kotlinx.android.synthetic.main.activity_dialpad.dialpad_holder
@@ -31,6 +32,7 @@ class DialpadActivity : SimpleActivity() {
     private val russianCharsMap = HashMap<Char, Int>()
     private var hasRussianLocale = false
     private var privateCursor: Cursor? = null
+    private var toneGeneratorHelper: ToneGeneratorHelper? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -296,9 +298,9 @@ class DialpadActivity : SimpleActivity() {
         if (config.dialpadBeeps) {
             if (char == '+') {
                 // 0 is being long pressed
-                playOnetimeTone('0')
+                toneGeneratorHelper?.playTone('0')
             } else {
-                playOnetimeTone(char)
+                toneGeneratorHelper?.playTone(char)
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -1,17 +1,22 @@
 package com.simplemobiletools.dialer.activities
 
+import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Intent
 import android.database.Cursor
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.provider.Telephony.Sms.Intents.SECRET_CODE_ACTION
 import android.telephony.PhoneNumberUtils
 import android.telephony.TelephonyManager
 import android.util.TypedValue
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import com.reddit.indicatorfastscroll.FastScrollItemIndicator
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
@@ -33,6 +38,9 @@ class DialpadActivity : SimpleActivity() {
     private var hasRussianLocale = false
     private var privateCursor: Cursor? = null
     private var toneGeneratorHelper: ToneGeneratorHelper? = null
+    private val longPressTimeout = ViewConfiguration.getLongPressTimeout().toLong()
+    private val longPressHandler = Handler(Looper.getMainLooper())
+    private val pressedKeys = mutableSetOf<Char>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -69,30 +77,19 @@ class DialpadActivity : SimpleActivity() {
             }
         }
 
-        dialpad_0_holder.setOnClickListener { dialpadPressed('0', it) }
-        dialpad_1_holder.setOnClickListener { dialpadPressed('1', it) }
-        dialpad_2_holder.setOnClickListener { dialpadPressed('2', it) }
-        dialpad_3_holder.setOnClickListener { dialpadPressed('3', it) }
-        dialpad_4_holder.setOnClickListener { dialpadPressed('4', it) }
-        dialpad_5_holder.setOnClickListener { dialpadPressed('5', it) }
-        dialpad_6_holder.setOnClickListener { dialpadPressed('6', it) }
-        dialpad_7_holder.setOnClickListener { dialpadPressed('7', it) }
-        dialpad_8_holder.setOnClickListener { dialpadPressed('8', it) }
-        dialpad_9_holder.setOnClickListener { dialpadPressed('9', it) }
+        setupCharClick(dialpad_1_holder, '1')
+        setupCharClick(dialpad_2_holder, '2')
+        setupCharClick(dialpad_3_holder, '3')
+        setupCharClick(dialpad_4_holder, '4')
+        setupCharClick(dialpad_5_holder, '5')
+        setupCharClick(dialpad_6_holder, '6')
+        setupCharClick(dialpad_7_holder, '7')
+        setupCharClick(dialpad_8_holder, '8')
+        setupCharClick(dialpad_9_holder, '9')
+        setupCharClick(dialpad_0_holder, '0')
+        setupCharClick(dialpad_asterisk_holder, '*', longClickable = false)
+        setupCharClick(dialpad_hashtag_holder, '#', longClickable = false)
 
-        dialpad_1_holder.setOnLongClickListener { speedDial(1); true }
-        dialpad_2_holder.setOnLongClickListener { speedDial(2); true }
-        dialpad_3_holder.setOnLongClickListener { speedDial(3); true }
-        dialpad_4_holder.setOnLongClickListener { speedDial(4); true }
-        dialpad_5_holder.setOnLongClickListener { speedDial(5); true }
-        dialpad_6_holder.setOnLongClickListener { speedDial(6); true }
-        dialpad_7_holder.setOnLongClickListener { speedDial(7); true }
-        dialpad_8_holder.setOnLongClickListener { speedDial(8); true }
-        dialpad_9_holder.setOnLongClickListener { speedDial(9); true }
-
-        dialpad_0_holder.setOnLongClickListener { dialpadPressed('+', null); true }
-        dialpad_asterisk_holder.setOnClickListener { dialpadPressed('*', it) }
-        dialpad_hashtag_holder.setOnClickListener { dialpadPressed('#', it) }
         dialpad_clear_char.setOnClickListener { clearChar(it) }
         dialpad_clear_char.setOnLongClickListener { clearInput(); true }
         dialpad_call_button.setOnClickListener { initCall(dialpad_input.value, 0) }
@@ -169,7 +166,6 @@ class DialpadActivity : SimpleActivity() {
     private fun dialpadPressed(char: Char, view: View?) {
         dialpad_input.addCharacter(char)
         maybePerformDialpadHapticFeedback(view)
-        maybePlayDialpadTone(char)
     }
 
     private fun clearChar(view: View) {
@@ -275,14 +271,15 @@ class DialpadActivity : SimpleActivity() {
         }
     }
 
-    private fun speedDial(id: Int) {
-        maybePlayDialpadTone(id.digitToChar())
-        if (dialpad_input.value.isEmpty()) {
+    private fun speedDial(id: Int): Boolean {
+        if (dialpad_input.value.length == 1) {
             val speedDial = speedDialValues.firstOrNull { it.id == id }
             if (speedDial?.isValid() == true) {
                 initCall(speedDial.number, -1)
+                return true
             }
         }
+        return false
     }
 
     private fun initRussianChars() {
@@ -296,13 +293,20 @@ class DialpadActivity : SimpleActivity() {
         russianCharsMap['ь'] = 9; russianCharsMap['э'] = 9; russianCharsMap['ю'] = 9; russianCharsMap['я'] = 9
     }
 
-    private fun maybePlayDialpadTone(char: Char) {
+    private fun startDialpadTone(char: Char) {
         if (config.dialpadBeeps) {
-            if (char == '+') {
-                // 0 is being long pressed
-                toneGeneratorHelper?.playTone('0')
+            pressedKeys.add(char)
+            toneGeneratorHelper?.startTone(char)
+        }
+    }
+
+    private fun stopDialpadTone(char: Char) {
+        if (config.dialpadBeeps) {
+            pressedKeys.remove(char)
+            if (pressedKeys.isEmpty()) {
+                toneGeneratorHelper?.stopTone()
             } else {
-                toneGeneratorHelper?.playTone(char)
+                startDialpadTone(pressedKeys.last())
             }
         }
     }
@@ -310,6 +314,45 @@ class DialpadActivity : SimpleActivity() {
     private fun maybePerformDialpadHapticFeedback(view: View?) {
         if (config.dialpadVibration) {
             view?.performHapticFeedback()
+        }
+    }
+
+    private fun performLongClick(view: View, char: Char) {
+        if (char == '0') {
+            clearChar(view)
+            dialpadPressed('+', view)
+        } else {
+            val result = speedDial(char.digitToInt())
+            if (result) {
+                stopDialpadTone(char)
+            }
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun setupCharClick(view: View, char: Char, longClickable: Boolean = true) {
+        view.isClickable = true
+        view.isLongClickable = true
+        view.setOnTouchListener { _, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    dialpadPressed(char, view)
+                    startDialpadTone(char)
+                    if (longClickable) {
+                        longPressHandler.removeCallbacksAndMessages(null)
+                        longPressHandler.postDelayed({
+                            performLongClick(view, char)
+                        }, longPressTimeout)
+                    }
+                }
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                    stopDialpadTone(char)
+                    if (longClickable) {
+                        longPressHandler.removeCallbacksAndMessages(null)
+                    }
+                }
+            }
+            false
         }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Intent
 import android.database.Cursor
-import android.graphics.Rect
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -355,10 +354,7 @@ class DialpadActivity : SimpleActivity() {
                     }
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    val outLocation = IntArray(2)
-                    view.getLocationOnScreen(outLocation)
-                    val rect = Rect(outLocation[0], outLocation[1], outLocation[0] + view.width, outLocation[1] + view.height)
-                    val viewContainsTouchEvent = rect.contains(event.rawX.roundToInt(), event.rawY.roundToInt())
+                    val viewContainsTouchEvent = view.boundingBox.contains(event.rawX.roundToInt(), event.rawY.roundToInt())
                     if (!viewContainsTouchEvent) {
                         stopDialpadTone(char)
                         if (longClickable) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Intent
 import android.database.Cursor
+import android.graphics.Rect
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -30,6 +31,8 @@ import kotlinx.android.synthetic.main.activity_dialpad.*
 import kotlinx.android.synthetic.main.activity_dialpad.dialpad_holder
 import kotlinx.android.synthetic.main.dialpad.*
 import java.util.*
+import kotlin.math.roundToInt
+
 
 class DialpadActivity : SimpleActivity() {
     private var allContacts = ArrayList<SimpleContact>()
@@ -349,6 +352,18 @@ class DialpadActivity : SimpleActivity() {
                     stopDialpadTone(char)
                     if (longClickable) {
                         longPressHandler.removeCallbacksAndMessages(null)
+                    }
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val outLocation = IntArray(2)
+                    view.getLocationOnScreen(outLocation)
+                    val rect = Rect(outLocation[0], outLocation[1], outLocation[0] + view.width, outLocation[1] + view.height)
+                    val viewContainsTouchEvent = rect.contains(event.rawX.roundToInt(), event.rawY.roundToInt())
+                    if (!viewContainsTouchEvent) {
+                        stopDialpadTone(char)
+                        if (longClickable) {
+                            longPressHandler.removeCallbacksAndMessages(null)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -47,6 +47,8 @@ class DialpadActivity : SimpleActivity() {
         speedDialValues = config.getSpeedDialValues()
         privateCursor = getMyContactsCursor(false, true)
 
+        toneGeneratorHelper = ToneGeneratorHelper(this)
+
         if (hasRussianLocale) {
             initRussianChars()
             dialpad_2_letters.append("\nАБВГ")

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -164,12 +164,13 @@ class DialpadActivity : SimpleActivity() {
 
     private fun dialpadPressed(char: Char, view: View?) {
         dialpad_input.addCharacter(char)
-        view?.performHapticFeedback()
+        maybePerformDialpadHapticFeedback(view)
+        maybePlayDialpadTone(char)
     }
 
     private fun clearChar(view: View) {
         dialpad_input.dispatchKeyEvent(dialpad_input.getKeyEvent(KeyEvent.KEYCODE_DEL))
-        view.performHapticFeedback()
+        maybePerformDialpadHapticFeedback(view)
     }
 
     private fun clearInput() {
@@ -271,6 +272,7 @@ class DialpadActivity : SimpleActivity() {
     }
 
     private fun speedDial(id: Int) {
+        maybePlayDialpadTone(id.digitToChar())
         if (dialpad_input.value.isEmpty()) {
             val speedDial = speedDialValues.firstOrNull { it.id == id }
             if (speedDial?.isValid() == true) {
@@ -288,5 +290,22 @@ class DialpadActivity : SimpleActivity() {
         russianCharsMap['ф'] = 7; russianCharsMap['х'] = 7; russianCharsMap['ц'] = 7; russianCharsMap['ч'] = 7
         russianCharsMap['ш'] = 8; russianCharsMap['щ'] = 8; russianCharsMap['ъ'] = 8; russianCharsMap['ы'] = 8
         russianCharsMap['ь'] = 9; russianCharsMap['э'] = 9; russianCharsMap['ю'] = 9; russianCharsMap['я'] = 9
+    }
+
+    private fun maybePlayDialpadTone(char: Char) {
+        if (config.dialpadBeeps) {
+            if (char == '+') {
+                // 0 is being long pressed
+                playOnetimeTone('0')
+            } else {
+                playOnetimeTone(char)
+            }
+        }
+    }
+
+    private fun maybePerformDialpadHapticFeedback(view: View?) {
+        if (config.dialpadVibration) {
+            view?.performHapticFeedback()
+        }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -327,6 +327,7 @@ class DialpadActivity : SimpleActivity() {
             val result = speedDial(char.digitToInt())
             if (result) {
                 stopDialpadTone(char)
+                clearChar(view)
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -304,7 +304,7 @@ class DialpadActivity : SimpleActivity() {
 
     private fun stopDialpadTone(char: Char) {
         if (config.dialpadBeeps) {
-            pressedKeys.remove(char)
+            if (!pressedKeys.remove(char)) return
             if (pressedKeys.isEmpty()) {
                 toneGeneratorHelper?.stopTone()
             } else {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/SettingsActivity.kt
@@ -39,6 +39,8 @@ class SettingsActivity : SimpleActivity() {
         setupDialPadOpen()
         setupGroupSubsequentCalls()
         setupStartNameWithSurname()
+        setupDialpadVibrations()
+        setupDialpadBeeps()
         setupShowCallConfirmation()
         setupDisableProximitySensor()
         setupDisableSwipeToAnswer()
@@ -203,6 +205,22 @@ class SettingsActivity : SimpleActivity() {
         settings_start_name_with_surname_holder.setOnClickListener {
             settings_start_name_with_surname.toggle()
             config.startNameWithSurname = settings_start_name_with_surname.isChecked
+        }
+    }
+
+    private fun setupDialpadVibrations() {
+        settings_dialpad_vibration.isChecked = config.dialpadVibration
+        settings_dialpad_vibration_holder.setOnClickListener {
+            settings_dialpad_vibration.toggle()
+            config.dialpadVibration = settings_dialpad_vibration.isChecked
+        }
+    }
+
+    private fun setupDialpadBeeps() {
+        settings_dialpad_beeps.isChecked = config.dialpadBeeps
+        settings_dialpad_beeps_holder.setOnClickListener {
+            settings_dialpad_beeps.toggle()
+            config.dialpadBeeps = settings_dialpad_beeps.isChecked
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/Context.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.PowerManager
 import com.simplemobiletools.commons.extensions.telecomManager
 import com.simplemobiletools.dialer.helpers.Config
+import com.simplemobiletools.dialer.helpers.ToneGeneratorHelper
 import com.simplemobiletools.dialer.models.SIMAccount
 
 val Context.config: Config get() = Config.newInstance(applicationContext)
@@ -43,4 +44,12 @@ fun Context.areMultipleSIMsAvailable(): Boolean {
     } catch (ignored: Exception) {
         false
     }
+}
+
+private var toneGeneratorHelperInstance: ToneGeneratorHelper? = null
+fun Context.playOnetimeTone(char: Char) {
+    if (toneGeneratorHelperInstance == null) {
+        toneGeneratorHelperInstance = ToneGeneratorHelper(this)
+    }
+    toneGeneratorHelperInstance?.playTone(char)
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/Context.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.os.PowerManager
 import com.simplemobiletools.commons.extensions.telecomManager
 import com.simplemobiletools.dialer.helpers.Config
-import com.simplemobiletools.dialer.helpers.ToneGeneratorHelper
 import com.simplemobiletools.dialer.models.SIMAccount
 
 val Context.config: Config get() = Config.newInstance(applicationContext)
@@ -44,12 +43,4 @@ fun Context.areMultipleSIMsAvailable(): Boolean {
     } catch (ignored: Exception) {
         false
     }
-}
-
-private var toneGeneratorHelperInstance: ToneGeneratorHelper? = null
-fun Context.playOnetimeTone(char: Char) {
-    if (toneGeneratorHelperInstance == null) {
-        toneGeneratorHelperInstance = ToneGeneratorHelper(this)
-    }
-    toneGeneratorHelperInstance?.playTone(char)
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/View.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/extensions/View.kt
@@ -1,0 +1,8 @@
+package com.simplemobiletools.dialer.extensions
+
+import android.graphics.Rect
+import android.view.View
+
+val View.boundingBox
+    get() = Rect().also { getGlobalVisibleRect(it) }
+

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallManager.kt
@@ -1,6 +1,7 @@
 package com.simplemobiletools.dialer.helpers
 
 import android.annotation.SuppressLint
+import android.os.Handler
 import android.telecom.Call
 import android.telecom.InCallService
 import android.telecom.VideoProfile
@@ -169,7 +170,9 @@ class CallManager {
 
         fun keypad(c: Char) {
             call?.playDtmfTone(c)
-            call?.stopDtmfTone()
+            Handler().postDelayed({
+                call?.stopDtmfTone()
+            }, DIALPAD_TONE_LENGTH_MS)
         }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallManager.kt
@@ -1,10 +1,12 @@
 package com.simplemobiletools.dialer.helpers
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Handler
 import android.telecom.Call
 import android.telecom.InCallService
 import android.telecom.VideoProfile
+import com.simplemobiletools.dialer.extensions.config
 import com.simplemobiletools.dialer.extensions.getStateCompat
 import com.simplemobiletools.dialer.extensions.hasCapability
 import com.simplemobiletools.dialer.extensions.isConference
@@ -168,11 +170,15 @@ class CallManager {
 
         fun getState() = getPrimaryCall()?.getStateCompat()
 
-        fun keypad(c: Char) {
-            call?.playDtmfTone(c)
-            Handler().postDelayed({
+        fun keypad(context: Context, char: Char) {
+            call?.playDtmfTone(char)
+            if (context.config.dialpadBeeps) {
+                Handler().postDelayed({
+                    call?.stopDtmfTone()
+                }, DIALPAD_TONE_LENGTH_MS)
+            } else {
                 call?.stopDtmfTone()
-            }, DIALPAD_TONE_LENGTH_MS)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Config.kt
@@ -71,4 +71,12 @@ class Config(context: Context) : BaseConfig(context) {
     var wasOverlaySnackbarConfirmed: Boolean
         get() = prefs.getBoolean(WAS_OVERLAY_SNACKBAR_CONFIRMED, false)
         set(wasOverlaySnackbarConfirmed) = prefs.edit().putBoolean(WAS_OVERLAY_SNACKBAR_CONFIRMED, wasOverlaySnackbarConfirmed).apply()
+
+    var dialpadVibration: Boolean
+        get() = prefs.getBoolean(DIALPAD_VIBRATION, true)
+        set(dialpadVibration) = prefs.edit().putBoolean(DIALPAD_VIBRATION, dialpadVibration).apply()
+
+    var dialpadBeeps: Boolean
+        get() = prefs.getBoolean(DIALPAD_BEEPS, false)
+        set(dialpadBeeps) = prefs.edit().putBoolean(DIALPAD_BEEPS, dialpadBeeps).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
@@ -1,8 +1,8 @@
 package com.simplemobiletools.dialer.helpers
 
+import com.simplemobiletools.commons.helpers.TAB_CALL_HISTORY
 import com.simplemobiletools.commons.helpers.TAB_CONTACTS
 import com.simplemobiletools.commons.helpers.TAB_FAVORITES
-import com.simplemobiletools.commons.helpers.TAB_CALL_HISTORY
 
 // shared prefs
 const val SPEED_DIAL = "speed_dial"
@@ -15,7 +15,8 @@ const val SHOW_TABS = "show_tabs"
 const val FAVORITES_CONTACTS_ORDER = "favorites_contacts_order"
 const val FAVORITES_CUSTOM_ORDER_SELECTED = "favorites_custom_order_selected"
 const val WAS_OVERLAY_SNACKBAR_CONFIRMED = "was_overlay_snackbar_confirmed"
-
+const val DIALPAD_VIBRATION = "touch_vibration"
+const val DIALPAD_BEEPS = "dialpad_beeps"
 const val ALL_TABS_MASK = TAB_CONTACTS or TAB_FAVORITES or TAB_CALL_HISTORY
 
 val tabsList = arrayListOf(TAB_CONTACTS, TAB_FAVORITES, TAB_CALL_HISTORY)

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
@@ -15,7 +15,7 @@ const val SHOW_TABS = "show_tabs"
 const val FAVORITES_CONTACTS_ORDER = "favorites_contacts_order"
 const val FAVORITES_CUSTOM_ORDER_SELECTED = "favorites_custom_order_selected"
 const val WAS_OVERLAY_SNACKBAR_CONFIRMED = "was_overlay_snackbar_confirmed"
-const val DIALPAD_VIBRATION = "touch_vibration"
+const val DIALPAD_VIBRATION = "dialpad_vibration"
 const val DIALPAD_BEEPS = "dialpad_beeps"
 const val ALL_TABS_MASK = TAB_CONTACTS or TAB_FAVORITES or TAB_CALL_HISTORY
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
@@ -24,3 +24,5 @@ val tabsList = arrayListOf(TAB_CONTACTS, TAB_FAVORITES, TAB_CALL_HISTORY)
 private const val PATH = "com.simplemobiletools.dialer.action."
 const val ACCEPT_CALL = PATH + "accept_call"
 const val DECLINE_CALL = PATH + "decline_call"
+
+const val DIALPAD_TONE_LENGTH_MS = 150L // The length of DTMF tones in milliseconds

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
@@ -1,0 +1,46 @@
+package com.simplemobiletools.dialer.helpers
+
+import android.content.Context
+import android.media.AudioManager
+import android.media.AudioManager.STREAM_DTMF
+import android.media.ToneGenerator
+
+class ToneGeneratorHelper(context: Context) {
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val toneGenerator = ToneGenerator(DIAL_TONE_STREAM_TYPE, TONE_RELATIVE_VOLUME)
+
+    private val isSilent: Boolean
+        get() = audioManager.ringerMode in arrayOf(AudioManager.RINGER_MODE_SILENT, AudioManager.RINGER_MODE_VIBRATE)
+
+    fun playTone(char: Char) = playTone(charToTone[char] ?: -1)
+
+    fun playTone(tone: Int, durationMs: Int = TONE_LENGTH_MS) {
+        if (tone != -1 && !isSilent) {
+            toneGenerator.stopTone()
+            toneGenerator.startTone(tone, durationMs)
+        }
+    }
+
+    companion object {
+        const val TONE_LENGTH_MS = 150 // The length of DTMF tones in milliseconds
+        const val TONE_RELATIVE_VOLUME = 80 // The DTMF tone volume relative to other sounds in the stream
+        const val DIAL_TONE_STREAM_TYPE = STREAM_DTMF
+
+        private val charToTone by lazy {
+            HashMap<Char, Int>().apply {
+                put('0', ToneGenerator.TONE_DTMF_0)
+                put('1', ToneGenerator.TONE_DTMF_1)
+                put('2', ToneGenerator.TONE_DTMF_2)
+                put('3', ToneGenerator.TONE_DTMF_3)
+                put('4', ToneGenerator.TONE_DTMF_4)
+                put('5', ToneGenerator.TONE_DTMF_5)
+                put('6', ToneGenerator.TONE_DTMF_6)
+                put('7', ToneGenerator.TONE_DTMF_7)
+                put('8', ToneGenerator.TONE_DTMF_8)
+                put('9', ToneGenerator.TONE_DTMF_9)
+                put('#', ToneGenerator.TONE_DTMF_P)
+                put('*', ToneGenerator.TONE_DTMF_S)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
@@ -9,13 +9,14 @@ class ToneGeneratorHelper(context: Context) {
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private val toneGenerator = ToneGenerator(DIAL_TONE_STREAM_TYPE, TONE_RELATIVE_VOLUME)
 
-    private val isSilent: Boolean
-        get() = audioManager.ringerMode in arrayOf(AudioManager.RINGER_MODE_SILENT, AudioManager.RINGER_MODE_VIBRATE)
+    private fun isSilent(): Boolean {
+        return audioManager.ringerMode in arrayOf(AudioManager.RINGER_MODE_SILENT, AudioManager.RINGER_MODE_VIBRATE)
+    }
 
     fun playTone(char: Char) = playTone(charToTone[char] ?: -1)
 
     fun playTone(tone: Int, durationMs: Int = DIALPAD_TONE_LENGTH_MS.toInt()) {
-        if (tone != -1 && !isSilent) {
+        if (tone != -1 && !isSilent()) {
             toneGenerator.stopTone()
             toneGenerator.startTone(tone, durationMs)
         }
@@ -25,21 +26,19 @@ class ToneGeneratorHelper(context: Context) {
         const val TONE_RELATIVE_VOLUME = 80 // The DTMF tone volume relative to other sounds in the stream
         const val DIAL_TONE_STREAM_TYPE = STREAM_DTMF
 
-        private val charToTone by lazy {
-            HashMap<Char, Int>().apply {
-                put('0', ToneGenerator.TONE_DTMF_0)
-                put('1', ToneGenerator.TONE_DTMF_1)
-                put('2', ToneGenerator.TONE_DTMF_2)
-                put('3', ToneGenerator.TONE_DTMF_3)
-                put('4', ToneGenerator.TONE_DTMF_4)
-                put('5', ToneGenerator.TONE_DTMF_5)
-                put('6', ToneGenerator.TONE_DTMF_6)
-                put('7', ToneGenerator.TONE_DTMF_7)
-                put('8', ToneGenerator.TONE_DTMF_8)
-                put('9', ToneGenerator.TONE_DTMF_9)
-                put('#', ToneGenerator.TONE_DTMF_P)
-                put('*', ToneGenerator.TONE_DTMF_S)
-            }
+        private val charToTone = HashMap<Char, Int>().apply {
+            put('0', ToneGenerator.TONE_DTMF_0)
+            put('1', ToneGenerator.TONE_DTMF_1)
+            put('2', ToneGenerator.TONE_DTMF_2)
+            put('3', ToneGenerator.TONE_DTMF_3)
+            put('4', ToneGenerator.TONE_DTMF_4)
+            put('5', ToneGenerator.TONE_DTMF_5)
+            put('6', ToneGenerator.TONE_DTMF_6)
+            put('7', ToneGenerator.TONE_DTMF_7)
+            put('8', ToneGenerator.TONE_DTMF_8)
+            put('9', ToneGenerator.TONE_DTMF_9)
+            put('#', ToneGenerator.TONE_DTMF_P)
+            put('*', ToneGenerator.TONE_DTMF_S)
         }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
@@ -13,14 +13,17 @@ class ToneGeneratorHelper(context: Context) {
         return audioManager.ringerMode in arrayOf(AudioManager.RINGER_MODE_SILENT, AudioManager.RINGER_MODE_VIBRATE)
     }
 
-    fun playTone(char: Char) = playTone(charToTone[char] ?: -1)
+    fun startTone(char: Char) {
+        startTone(charToTone[char] ?: -1)
+    }
 
-    fun playTone(tone: Int, durationMs: Int = DIALPAD_TONE_LENGTH_MS.toInt()) {
+    private fun startTone(tone: Int) {
         if (tone != -1 && !isSilent()) {
-            toneGenerator.stopTone()
-            toneGenerator.startTone(tone, durationMs)
+            toneGenerator.startTone(tone)
         }
     }
+
+    fun stopTone() = toneGenerator.stopTone()
 
     companion object {
         const val TONE_RELATIVE_VOLUME = 80 // The DTMF tone volume relative to other sounds in the stream

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
@@ -14,7 +14,7 @@ class ToneGeneratorHelper(context: Context) {
 
     fun playTone(char: Char) = playTone(charToTone[char] ?: -1)
 
-    fun playTone(tone: Int, durationMs: Int = TONE_LENGTH_MS) {
+    fun playTone(tone: Int, durationMs: Int = DIALPAD_TONE_LENGTH_MS.toInt()) {
         if (tone != -1 && !isSilent) {
             toneGenerator.stopTone()
             toneGenerator.startTone(tone, durationMs)
@@ -22,7 +22,6 @@ class ToneGeneratorHelper(context: Context) {
     }
 
     companion object {
-        const val TONE_LENGTH_MS = 150 // The length of DTMF tones in milliseconds
         const val TONE_RELATIVE_VOLUME = 80 // The DTMF tone volume relative to other sounds in the stream
         const val DIAL_TONE_STREAM_TYPE = STREAM_DTMF
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -189,7 +189,7 @@
                     style="@style/SettingsHolderCheckboxStyle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@drawable/ripple_bottom_corners">
+                    android:background="@drawable/ripple_background">
 
                     <com.simplemobiletools.commons.views.MyAppCompatCheckbox
                         android:id="@+id/settings_start_name_with_surname"
@@ -197,6 +197,38 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/start_name_with_surname" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_dialpad_vibration_holder"
+                    style="@style/SettingsHolderCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_background">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_dialpad_vibration"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/dialpad_vibrations" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_dialpad_beeps_holder"
+                    style="@style/SettingsHolderCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_bottom_corners">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_dialpad_beeps"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/dialpad_beeps" />
 
                 </RelativeLayout>
             </LinearLayout>


### PR DESCRIPTION
This PR addresses issues https://github.com/SimpleMobileTools/Simple-Dialer/issues/325 and https://github.com/SimpleMobileTools/Simple-Dialer/issues/420

System settings are still ignored but dialpad tones and vibrations can now be controlled using the in-app toggles:

<img src="https://user-images.githubusercontent.com/36371707/187047886-6fef073d-0487-4646-8c90-6d838ff597f1.png" width="264" />

**Note:** In-call dialpad still uses the `Call.playDtmfTone()` method as its needed for [DTMF signaling](https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling).