### PR TITLE
Properly clear missed calls on start

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
@@ -42,7 +42,6 @@ import kotlinx.android.synthetic.main.fragment_favorites.*
 import kotlinx.android.synthetic.main.fragment_recents.*
 import me.grantland.widget.AutofitHelper
 
-
 class MainActivity : SimpleActivity() {
     private var isSearchOpen = false
     private var launchedDialer = false
@@ -456,8 +455,7 @@ class MainActivity : SimpleActivity() {
             // should update the database and reset the cached missed call count in MissedCallNotifier.java
             // https://android.googlesource.com/platform/packages/services/Telecomm/+/master/src/com/android/server/telecom/ui/MissedCallNotifierImpl.java#170
             telecomManager.cancelMissedCallsNotification()
-        } catch (e: Exception) {
-            e.printStackTrace()
+        } catch (ignored: Exception) {
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Dialer/issues/256

Calling [TelecomService.cancelMissedCallsNotification()](https://android.googlesource.com/platform/packages/services/Telecomm/+/3901e51/src/com/android/server/telecom/TelecomServiceImpl.java#438) calls the [clearMissedCalls()](https://android.googlesource.com/platform/packages/services/Telecomm/+/3901e51/src/com/android/server/telecom/TelecomServiceImpl.java#90) method from [MissedCallNotifier.java](https://android.googlesource.com/platform/packages/services/Telecomm/+/master/src/com/android/server/telecom/ui/MissedCallNotifierImpl.java#170). MissedCallNotifier.clearMissedCalls() clears the [internal missed call cache count](https://android.googlesource.com/platform/packages/services/Telecomm/+/master/src/com/android/server/telecom/ui/MissedCallNotifierImpl.java#443) (while also updating the database so we don't have to) and fixes the bug.

(Not yet sure if this is how system missed call notifications are supposed to work or if the always increasing cache count is just a bug)
