### PR TITLE
Persistent notification fix

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallManager.kt
@@ -109,6 +109,9 @@ class CallManager {
                     listener.onStateChanged()
                 }
             }
+
+            // remove all disconnected calls manually in case they are still here
+            calls.removeAll { it.getStateCompat() == Call.STATE_DISCONNECTED }
         }
 
         fun getPrimaryCall(): Call? {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallNotificationManager.kt
@@ -20,7 +20,7 @@ import com.simplemobiletools.dialer.extensions.powerManager
 import com.simplemobiletools.dialer.receivers.CallActionReceiver
 
 class CallNotificationManager(private val context: Context) {
-    private val CALL_NOTIFICATION_ID = 1
+    private val CALL_NOTIFICATION_ID = 42
     private val ACCEPT_CALL_CODE = 0
     private val DECLINE_CALL_CODE = 1
     private val notificationManager = context.notificationManager
@@ -99,7 +99,10 @@ class CallNotificationManager(private val context: Context) {
             }
 
             val notification = builder.build()
-            notificationManager.notify(CALL_NOTIFICATION_ID, notification)
+            // it's rare but possible for the call state to change by now
+            if (CallManager.getState() == callState) {
+                notificationManager.notify(CALL_NOTIFICATION_ID, notification)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/services/CallService.kt
@@ -18,7 +18,9 @@ class CallService : InCallService() {
     private val callListener = object : Call.Callback() {
         override fun onStateChanged(call: Call, state: Int) {
             super.onStateChanged(call, state)
-            if (state != Call.STATE_DISCONNECTED) {
+            if (state == Call.STATE_DISCONNECTED || state == Call.STATE_DISCONNECTING) {
+                callNotificationManager.cancelNotification()
+            } else {
                 callNotificationManager.setupNotification()
             }
         }


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Dialer/issues/326

### Changes
- Cancel notification in `onStateChange` as soon as "disconnected" or "disconnecting" state is received. Avoid creating notifications if the call state has already changed.
- Remove disconnected calls from `CallManager` manually


[_Fix not yet fully confirmed by any reporters_](https://github.com/SimpleMobileTools/Simple-Dialer/issues/326#issuecomment-1286666438)