### PR TITLE
Fixed display for starting with surname (#544)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -274,7 +274,7 @@ class DialpadActivity : SimpleActivity() {
 
         letter_fastscroller.setupWithRecyclerView(dialpad_list, { position ->
             try {
-                val name = filtered[position].name
+                val name = filtered[position].getNameToDisplay()
                 val character = if (name.isNotEmpty()) name.substring(0, 1) else ""
                 FastScrollItemIndicator.Text(character.toUpperCase(Locale.getDefault()))
             } catch (e: Exception) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
@@ -41,6 +41,7 @@ import me.grantland.widget.AutofitHelper
 class MainActivity : SimpleActivity() {
     private var launchedDialer = false
     private var storedShowTabs = 0
+    private var storedStartNameWithSurname = false
     var cachedContacts = ArrayList<Contact>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -106,6 +107,13 @@ class MainActivity : SimpleActivity() {
             it?.setupColors(getProperTextColor(), getProperPrimaryColor(), getProperPrimaryColor())
         }
 
+        val configStartNameWithSurname = config.startNameWithSurname
+        if (storedStartNameWithSurname != configStartNameWithSurname) {
+            contacts_fragment?.startNameWithSurnameChanged(configStartNameWithSurname)
+            favorites_fragment?.startNameWithSurnameChanged(configStartNameWithSurname)
+            storedStartNameWithSurname = config.startNameWithSurname
+        }
+
         if (!main_menu.isSearchOpen) {
             refreshItems(true)
         }
@@ -119,6 +127,7 @@ class MainActivity : SimpleActivity() {
     override fun onPause() {
         super.onPause()
         storedShowTabs = config.showTabs
+        storedStartNameWithSurname = config.startNameWithSurname
         config.lastUsedViewPagerPage = view_pager.currentItem
     }
 
@@ -373,6 +382,7 @@ class MainActivity : SimpleActivity() {
 
         main_tabs_holder.beGoneIf(main_tabs_holder.tabCount == 1)
         storedShowTabs = config.showTabs
+        storedStartNameWithSurname = config.startNameWithSurname
     }
 
     private fun getTabIcon(position: Int): Drawable {
@@ -417,7 +427,7 @@ class MainActivity : SimpleActivity() {
         }
     }
 
-    private fun refreshFragments() {
+    fun refreshFragments() {
         contacts_fragment?.refreshItems()
         favorites_fragment?.refreshItems()
         recents_fragment?.refreshItems()

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/ManageSpeedDialActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/ManageSpeedDialActivity.kt
@@ -5,7 +5,6 @@ import com.google.gson.Gson
 import com.simplemobiletools.commons.extensions.updateTextColors
 import com.simplemobiletools.commons.helpers.ContactsHelper
 import com.simplemobiletools.commons.helpers.NavigationIcon
-import com.simplemobiletools.commons.helpers.SimpleContactsHelper
 import com.simplemobiletools.commons.models.contacts.Contact
 import com.simplemobiletools.dialer.R
 import com.simplemobiletools.dialer.adapters.SpeedDialAdapter
@@ -55,7 +54,7 @@ class ManageSpeedDialActivity : SimpleActivity(), RemoveSpeedDialListener {
 
             SelectContactDialog(this, allContacts) { selectedContact ->
                 speedDialValues.first { it.id == clickedContact.id }.apply {
-                    displayName = selectedContact.name
+                    displayName = selectedContact.getNameToDisplay()
                     number = selectedContact.phoneNumbers.first().normalizedNumber
                 }
                 updateAdapter()

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/adapters/ContactsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/adapters/ContactsAdapter.kt
@@ -184,7 +184,7 @@ class ContactsAdapter(
         val itemsCnt = selectedKeys.size
         val firstItem = getSelectedItems().firstOrNull() ?: return
         val items = if (itemsCnt == 1) {
-            "\"${firstItem.name}\""
+            "\"${firstItem.getNameToDisplay()}\""
         } else {
             resources.getQuantityString(R.plurals.delete_contacts, itemsCnt, itemsCnt)
         }
@@ -242,7 +242,7 @@ class ContactsAdapter(
         val contact = contacts.firstOrNull { selectedKeys.contains(it.rawId) } ?: return
         val manager = activity.shortcutManager
         if (manager.isRequestPinShortcutSupported) {
-            SimpleContactsHelper(activity).getShortcutImage(contact.photoUri, contact.name) { image ->
+            SimpleContactsHelper(activity).getShortcutImage(contact.photoUri, contact.getNameToDisplay()) { image ->
                 activity.runOnUiThread {
                     activity.handlePermission(PERMISSION_CALL_PHONE) { hasPermission ->
                         val action = if (hasPermission) Intent.ACTION_CALL else Intent.ACTION_DIAL
@@ -251,7 +251,7 @@ class ContactsAdapter(
                         }
 
                         val shortcut = ShortcutInfo.Builder(activity, contact.hashCode().toString())
-                            .setShortLabel(contact.name)
+                            .setShortLabel(contact.getNameToDisplay())
                             .setIcon(Icon.createWithBitmap(image))
                             .setIntent(intent)
                             .build()
@@ -277,11 +277,12 @@ class ContactsAdapter(
                 setTextColor(textColor)
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, fontSize)
 
-                text = if (textToHighlight.isEmpty()) contact.name else {
-                    if (contact.name.contains(textToHighlight, true)) {
-                        contact.name.highlightTextPart(textToHighlight, properPrimaryColor)
+                val name = contact.getNameToDisplay()
+                text = if (textToHighlight.isEmpty()) name else {
+                    if (name.contains(textToHighlight, true)) {
+                        name.highlightTextPart(textToHighlight, properPrimaryColor)
                     } else {
-                        contact.name.highlightTextFromNumbers(textToHighlight, properPrimaryColor)
+                        name.highlightTextFromNumbers(textToHighlight, properPrimaryColor)
                     }
                 }
             }
@@ -306,7 +307,7 @@ class ContactsAdapter(
             }
 
             if (!activity.isDestroyed) {
-                SimpleContactsHelper(context).loadContactImage(contact.photoUri, findViewById(R.id.item_contact_image), contact.name)
+                SimpleContactsHelper(context).loadContactImage(contact.photoUri, findViewById(R.id.item_contact_image), contact.getNameToDisplay())
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/adapters/RecentCallsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/adapters/RecentCallsAdapter.kt
@@ -275,13 +275,14 @@ class RecentCallsAdapter(
     private fun setupView(view: View, call: RecentCall) {
         view.apply {
             item_recents_holder.isSelected = selectedKeys.contains(call.id)
-            var nameToShow = SpannableString(call.name)
+            val name = findContactByCall(call)?.getNameToDisplay() ?: call.name
+            var nameToShow = SpannableString(name)
             if (call.specificType.isNotEmpty()) {
-                nameToShow = SpannableString("${call.name} - ${call.specificType}")
+                nameToShow = SpannableString("${name} - ${call.specificType}")
 
                 // show specific number at "Show call details" dialog too
                 if (refreshItemsListener == null) {
-                    nameToShow = SpannableString("${call.name} - ${call.specificType}, ${call.specificNumber}")
+                    nameToShow = SpannableString("${name} - ${call.specificType}, ${call.specificNumber}")
                 }
             }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/dialogs/SelectContactDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/dialogs/SelectContactDialog.kt
@@ -23,7 +23,7 @@ class SelectContactDialog(val activity: SimpleActivity, contacts: ArrayList<Cont
 
             letter_fastscroller.setupWithRecyclerView(select_contact_list, { position ->
                 try {
-                    val name = contacts[position].name
+                    val name = contacts[position].getNameToDisplay()
                     val character = if (name.isNotEmpty()) name.substring(0, 1) else ""
                     FastScrollItemIndicator.Text(character.toUpperCase(Locale.getDefault()))
                 } catch (e: Exception) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/ContactsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/ContactsFragment.kt
@@ -112,7 +112,7 @@ class ContactsFragment(context: Context, attributeSet: AttributeSet) : MyViewPag
     private fun setupLetterFastscroller(contacts: ArrayList<Contact>) {
         letter_fastscroller.setupWithRecyclerView(fragment_list, { position ->
             try {
-                val name = contacts[position].name
+                val name = contacts[position].getNameToDisplay()
                 val character = if (name.isNotEmpty()) name.substring(0, 1) else ""
                 FastScrollItemIndicator.Text(character.toUpperCase(Locale.getDefault()).normalizeString())
             } catch (e: Exception) {
@@ -130,7 +130,7 @@ class ContactsFragment(context: Context, attributeSet: AttributeSet) : MyViewPag
     override fun onSearchQueryChanged(text: String) {
             val shouldNormalize = text.normalizeString() == text
             val filtered = allContacts.filter {
-                getProperText(it.name, shouldNormalize).contains(text, true) ||
+                getProperText(it.getNameToDisplay(), shouldNormalize).contains(text, true) ||
                     getProperText(it.nickname, shouldNormalize).contains(text, true) ||
                     it.phoneNumbers.any {
                         text.normalizePhoneNumber().isNotEmpty() && it.normalizedNumber.contains(text.normalizePhoneNumber(), true)
@@ -145,7 +145,7 @@ class ContactsFragment(context: Context, attributeSet: AttributeSet) : MyViewPag
             } as ArrayList
 
             filtered.sortBy {
-                val nameToDisplay = it.name
+                val nameToDisplay = it.getNameToDisplay()
                 !getProperText(nameToDisplay, shouldNormalize).startsWith(text, true) && !nameToDisplay.contains(text, true)
             }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/FavoritesFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/FavoritesFragment.kt
@@ -92,7 +92,7 @@ class FavoritesFragment(context: Context, attributeSet: AttributeSet) : MyViewPa
                     enableDrag = true,
                 ) {
                     if (context.config.showCallConfirmation) {
-                        CallConfirmationDialog(activity as SimpleActivity, (it as Contact).name) {
+                        CallConfirmationDialog(activity as SimpleActivity, (it as Contact).getNameToDisplay()) {
                             callContact(it)
                         }
                     } else {
@@ -167,7 +167,7 @@ class FavoritesFragment(context: Context, attributeSet: AttributeSet) : MyViewPa
     private fun setupLetterFastscroller(contacts: ArrayList<Contact>) {
         letter_fastscroller.setupWithRecyclerView(fragment_list, { position ->
             try {
-                val name = contacts[position].name
+                val name = contacts[position].getNameToDisplay()
                 val character = if (name.isNotEmpty()) name.substring(0, 1) else ""
                 FastScrollItemIndicator.Text(character.toUpperCase(Locale.getDefault()).normalizeString())
             } catch (e: Exception) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/MyViewPagerFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/MyViewPagerFragment.kt
@@ -6,7 +6,11 @@ import android.widget.RelativeLayout
 import com.simplemobiletools.commons.adapters.MyRecyclerViewAdapter
 import com.simplemobiletools.commons.extensions.getProperPrimaryColor
 import com.simplemobiletools.commons.extensions.getProperTextColor
+import com.simplemobiletools.commons.helpers.SORT_BY_FIRST_NAME
+import com.simplemobiletools.commons.helpers.SORT_BY_SURNAME
+import com.simplemobiletools.dialer.activities.MainActivity
 import com.simplemobiletools.dialer.activities.SimpleActivity
+import com.simplemobiletools.dialer.adapters.ContactsAdapter
 import com.simplemobiletools.dialer.extensions.config
 import com.simplemobiletools.dialer.helpers.Config
 import kotlinx.android.synthetic.main.fragment_letters_layout.view.*
@@ -24,6 +28,15 @@ abstract class MyViewPagerFragment(context: Context, attributeSet: AttributeSet)
 
             setupFragment()
             setupColors(activity.getProperTextColor(), activity.getProperPrimaryColor(), activity.getProperPrimaryColor())
+        }
+    }
+
+    fun startNameWithSurnameChanged(startNameWithSurname: Boolean) {
+        if (this !is RecentsFragment) {
+            (fragment_list.adapter as? ContactsAdapter)?.apply {
+                config.sorting = if (startNameWithSurname) SORT_BY_SURNAME else SORT_BY_FIRST_NAME
+                (this@MyViewPagerFragment.activity!! as MainActivity).refreshFragments()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/RecentsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/RecentsFragment.kt
@@ -7,7 +7,6 @@ import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.ContactsHelper
 import com.simplemobiletools.commons.helpers.MyContactsContentProvider
 import com.simplemobiletools.commons.helpers.PERMISSION_READ_CALL_LOG
-import com.simplemobiletools.commons.helpers.SimpleContactsHelper
 import com.simplemobiletools.dialer.R
 import com.simplemobiletools.dialer.activities.SimpleActivity
 import com.simplemobiletools.dialer.adapters.RecentCallsAdapter
@@ -58,7 +57,7 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
                     if (privateContacts.isNotEmpty()) {
                         val privateContact = privateContacts.firstOrNull { it.doesContainPhoneNumber(recent.phoneNumber) }
                         if (privateContact != null) {
-                            recent.name = privateContact.name
+                            recent.name = privateContact.getNameToDisplay()
                             wasNameFilled = true
                         }
                     }
@@ -66,7 +65,7 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
                     if (!wasNameFilled) {
                         val contact = contacts.filter { it.phoneNumbers.isNotEmpty() }.firstOrNull { it.phoneNumbers.first().normalizedNumber == recent.phoneNumber }
                         if (contact != null) {
-                            recent.name = contact.name
+                            recent.name = contact.getNameToDisplay()
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallContactHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallContactHelper.kt
@@ -7,7 +7,6 @@ import com.simplemobiletools.commons.extensions.getMyContactsCursor
 import com.simplemobiletools.commons.extensions.getPhoneNumberTypeText
 import com.simplemobiletools.commons.helpers.ContactsHelper
 import com.simplemobiletools.commons.helpers.MyContactsContentProvider
-
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.dialer.R
 import com.simplemobiletools.dialer.extensions.isConference
@@ -54,7 +53,7 @@ fun getCallContact(context: Context, call: Call?, callback: (CallContact) -> Uni
                 callContact.number = number
                 val contact = contacts.firstOrNull { it.doesHavePhoneNumber(number) }
                 if (contact != null) {
-                    callContact.name = contact.name
+                    callContact.name = contact.getNameToDisplay()
                     callContact.photoUri = contact.photoUri
 
                     if (contact.phoneNumbers.size > 1) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -101,7 +101,7 @@ class RecentsHelper(private val context: Context) {
                                 val curNumber = contact.phoneNumbers.first().normalizedNumber
                                 if (curNumber.length >= COMPARABLE_PHONE_NUMBER_LENGTH) {
                                     if (curNumber.substring(curNumber.length - COMPARABLE_PHONE_NUMBER_LENGTH) == normalizedNumber.substring(normalizedNumber.length - COMPARABLE_PHONE_NUMBER_LENGTH)) {
-                                        contactsNumbersMap[number] = contact.name
+                                        contactsNumbersMap[number] = contact.getNameToDisplay()
                                         return@firstOrNull true
                                     }
                                 }


### PR DESCRIPTION
Closes #544

- Added starting by surname in every place where name is shown (via `getNameToDisplay()`)
- Added similar sorting behavior to Simple Contacts when changing "Start name with surname" value
- Added refreshing fragments after changing setting value (it was missing on current master, despite working on latest released version)

<img src="https://user-images.githubusercontent.com/85929121/224131303-b56f1ae1-2dac-4494-b699-71cffca254d7.png" width="350">