### PR TITLE
fix: Remove dialpadBeeps check for DTMF tone handling

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
@@ -400,7 +400,7 @@ class CallActivity : SimpleActivity() {
     }
 
     private fun dialpadPressed(char: Char) {
-        CallManager.keypad(this, char)
+        CallManager.keypad(char)
         dialpad_input.addCharacter(char)
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/CallManager.kt
@@ -1,13 +1,11 @@
 package com.simplemobiletools.dialer.helpers
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.os.Handler
 import android.telecom.Call
 import android.telecom.CallAudioState
 import android.telecom.InCallService
 import android.telecom.VideoProfile
-import com.simplemobiletools.dialer.extensions.config
 import com.simplemobiletools.dialer.extensions.getStateCompat
 import com.simplemobiletools.dialer.extensions.hasCapability
 import com.simplemobiletools.dialer.extensions.isConference
@@ -202,13 +200,11 @@ class CallManager {
 
         fun getState() = getPrimaryCall()?.getStateCompat()
 
-        fun keypad(context: Context, char: Char) {
-            if (context.config.dialpadBeeps) {
+        fun keypad(char: Char) {
                 call?.playDtmfTone(char)
                 Handler().postDelayed({
                     call?.stopDtmfTone()
                 }, DIALPAD_TONE_LENGTH_MS)
-            }
         }
     }
 }


### PR DESCRIPTION
This PR addresses an issue where the DTMF tones were confused with dialpad tones in the keypad function. The previous implementation prevented users from inputting a number during a call when dialpadBeeps was set to false.

DTMF (Dual-Tone Multi-Frequency) tones should be played every time a user inputs a number during a call because they serve an essential function in phone systems. DTMF tones are used to communicate with the telecommunication system during a call.

fix: #573 