### PR TITLE
Fix - Show missing call confirmation box

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -288,15 +288,10 @@ class DialpadActivity : SimpleActivity() {
         })
 
         ContactsAdapter(this, filtered, dialpad_list, null, text) {
-            startCallIntent((it as Contact).phoneNumbers.first().normalizedNumber)
-        }.apply {
-            dialpad_list.adapter = this
-        }
-        ContactsAdapter(this, filtered, dialpad_list, null, text) {
             //Fix#DP001: Show missing call confirmation box
             val contact = it as Contact
             if (config.showCallConfirmation) {
-                CallConfirmationDialog(this as SimpleActivity, contact.name) {
+                CallConfirmationDialog(this as SimpleActivity, System.lineSeparator()+contact.name) {
                     startCallIntent((it as Contact).phoneNumbers.first().normalizedNumber)
                 }
             } else {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -20,6 +20,7 @@ import android.view.ViewConfiguration
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import com.reddit.indicatorfastscroll.FastScrollItemIndicator
+import com.simplemobiletools.commons.dialogs.CallConfirmationDialog
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
 import com.simplemobiletools.commons.models.contacts.Contact
@@ -291,7 +292,19 @@ class DialpadActivity : SimpleActivity() {
         }.apply {
             dialpad_list.adapter = this
         }
-
+        ContactsAdapter(this, filtered, dialpad_list, null, text) {
+            //Fix#DP001: Show missing call confirmation box
+            val contact = it as Contact
+            if (config.showCallConfirmation) {
+                CallConfirmationDialog(this as SimpleActivity, contact.name) {
+                    startCallIntent((it as Contact).phoneNumbers.first().normalizedNumber)
+                }
+            } else {
+                startCallIntent((it as Contact).phoneNumbers.first().normalizedNumber)
+            }
+        }.apply {
+            dialpad_list.adapter = this
+        }
         dialpad_placeholder.beVisibleIf(filtered.isEmpty())
         dialpad_list.beVisibleIf(filtered.isNotEmpty())
     }


### PR DESCRIPTION
**Bug description:** With enabled setting "Show a call confirmation dialog before initiating a call": On main window, if keypad icon pressed, contacts list and  keypad are displayed. Then, if you tap on a contact item in list,the call starts without a confirmation dialog box!

_**(It's my first use of Github and my first pull request!. So, I'm not yet confortable with the process...)**_