### PR TITLE
Fix : Show missing call confirmation box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,5 @@
-# Simple Dialer
-<img alt="Logo" src="graphics/icon.png" width="120" />
-
-A lightweight app for handling your calls, no matter where are you. Comes with a handy call log for easy call initiation. You can now easily dial numbers using this amazing dial pad without any problem as this dial pad gives you different things to ease up your overall experience while making a call. Stay connected with your friends and family while having a smooth experience in this app. With bigger numbers and letters, it is now easier for you to see and dial numbers. Using this dialpad, you can access your contacts and maintain a call log with ease.
-
-There is a quick dialpad at your service too, with smart contact suggestions. It supports letters too. You can use the quick search for finding your favorite contacts not just in the contact list, but also at the call history. Call log entries can be removed either one by one, but it can also be cleared out at once.
-
-You can easily block phone numbers to avoid unwanted incoming calls. This feature is missing in most of the apps present on the store. Using this feature, you can choose who can call you. By this feature, the security of the user can be maintained easily by blocking numbers that are useless or threatening. You can block calls from not saved contacts too.
-
-With advanced security features of this app, the numbers you type are tightly secured so you can have a seamless experience without worrying about your data going in wrong hands. Each of your phone number is safe with you. 
-
-Supported Speed dialing makes calling your favorite contacts with this true phone a breeze. You can make any phone number your favorite so you can quickly dial it. This way, you can easily make contacts with people without finding deep down in other numbers.
-
-To help you manage your calls quickly the phone number app also supports favorite contacts and creating shortcuts of any contact on the home screen.
-
-It comes with material design and dark theme by default, provides great user experience for easy usage. The lack of internet access gives you more privacy, security and stability than other apps.
-
-Contains no ads or unnecessary permissions. It is fully opensource, provides customizable colors. Keeping track of call logs for different phone number is also a plus point of this app.
-
-Check out the full suite of Simple Tools here:  
-https://www.simplemobiletools.com
-
-Facebook:  
-https://www.facebook.com/simplemobiletools
-
-Reddit:  
-https://www.reddit.com/r/SimpleMobileTools
-
-Telegram:  
-https://t.me/SimpleMobileTools
-
-<a href='https://play.google.com/store/apps/details?id=com.simplemobiletools.dialer'><img src='https://simplemobiletools.com/images/button-google-play.svg' alt='Get it on Google Play' height='45' /></a>
-<a href='https://f-droid.org/packages/com.simplemobiletools.dialer'><img src='https://simplemobiletools.com/images/button-f-droid.png' alt='Get it on F-Droid' height='45' /></a>
-
-<div style="display:flex;">
-<img alt="App image" src="fastlane/metadata/android/en-US/images/phoneScreenshots/1_en-US.jpeg" width="30%">
-<img alt="App image" src="fastlane/metadata/android/en-US/images/phoneScreenshots/2_en-US.jpeg" width="30%">
-<img alt="App image" src="fastlane/metadata/android/en-US/images/phoneScreenshots/3_en-US.jpeg" width="30%">
-</div>
+# Simple Dialer 5.17.6 Fix 
+Fix : Show missing call confirmation box.
+Bug description: With enabled setting "Show a call confirmation dialog before initiating a call":
+On main window, if keypad icon pressed, contacts list and  keypad are displayed.
+Then, if you tap on a contact item in list,the call starts without a confirmation dialog box!

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -20,6 +20,7 @@ import android.view.ViewConfiguration
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import com.reddit.indicatorfastscroll.FastScrollItemIndicator
+import com.simplemobiletools.commons.dialogs.CallConfirmationDialog
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
 import com.simplemobiletools.commons.models.contacts.Contact
@@ -287,11 +288,18 @@ class DialpadActivity : SimpleActivity() {
         })
 
         ContactsAdapter(this, filtered, dialpad_list, null, text) {
-            startCallIntent((it as Contact).phoneNumbers.first().normalizedNumber)
+            //Fix#DP001 : Show missing call confirmation box
+            val contact = it as Contact
+            if (config.showCallConfirmation) {
+                CallConfirmationDialog(this as SimpleActivity, contact.name) {
+                    startCallIntent((it as Contact).phoneNumbers.first().normalizedNumber)
+                }
+            } else {
+                startCallIntent((it as Contact).phoneNumbers.first().normalizedNumber)
+            }
         }.apply {
             dialpad_list.adapter = this
         }
-
         dialpad_placeholder.beVisibleIf(filtered.isEmpty())
         dialpad_list.beVisibleIf(filtered.isNotEmpty())
     }


### PR DESCRIPTION
**Bug description:** With enabled setting "Show a call confirmation dialog before initiating a call". On main window, if keypad icon pressed, contacts list and  keypad are displayed. Then, if you tap on a contact item in list,the call starts without a confirmation dialog box!

**_It's my first use of Github and my first pull request too. So, I'm not yet confortable with the process..._**