### PR TITLE
Dev add complete androidcontact

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:dfe84c0ee2'
+    // implementation 'com.github.SimpleMobileTools:Simple-Commons:ee2e127758'
+    implementation project(path: ':commons')
     implementation 'com.github.tibbi:IndicatorFastScroll:4524cd0b61'
     implementation 'me.grantland:autofittextview:0.2.1'
 }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -256,7 +256,7 @@ class DialpadActivity : SimpleActivity() {
         (dialpad_list.adapter as? ContactsAdapter)?.finishActMode()
 
         val filtered = allContacts.filter {
-            var convertedName = PhoneNumberUtils.convertKeypadLettersToDigits(it.name.normalizeString())
+            var convertedName = PhoneNumberUtils.convertKeypadLettersToDigits(it.displayname.normalizeString())
 
             if (hasRussianLocale) {
                 var currConvertedName = ""

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : SimpleActivity() {
         }
 
         setupTabs()
-        Contact.sorting = config.sorting
+        Contact.setSortOrder(config.sorting)
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/adapters/RecentCallsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/adapters/RecentCallsAdapter.kt
@@ -247,7 +247,7 @@ class RecentCallsAdapter(
     }
 
     private fun findContactByCall(recentCall: RecentCall): Contact? {
-        return (activity as MainActivity).cachedContacts.find { it.name == recentCall.name && it.doesHavePhoneNumber(recentCall.phoneNumber) }
+        return (activity as MainActivity).cachedContacts.find { it.displayname == recentCall.name && it.doesHavePhoneNumber(recentCall.phoneNumber) }
     }
 
     private fun launchContactDetailsIntent(contact: Contact?) {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/ContactsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/ContactsFragment.kt
@@ -132,17 +132,19 @@ class ContactsFragment(context: Context, attributeSet: AttributeSet) : MyViewPag
             val shouldNormalize = text.normalizeString() == text
             val filtered = allContacts.filter {
                 getProperText(it.getNameToDisplay(), shouldNormalize).contains(text, true) ||
-                    getProperText(it.nickname, shouldNormalize).contains(text, true) ||
+                    it.nicknames.any {
+                        nickname -> getProperText(nickname.name, shouldNormalize).contains(text, true)
+                    } ||
                     it.phoneNumbers.any {
                         text.normalizePhoneNumber().isNotEmpty() && it.normalizedNumber.contains(text.normalizePhoneNumber(), true)
                     } ||
-                    it.emails.any { it.value.contains(text, true) } ||
-                    it.addresses.any { getProperText(it.value, shouldNormalize).contains(text, true) } ||
-                    it.IMs.any { it.value.contains(text, true) } ||
+                    it.emails.any { it.address.contains(text, true) } ||
+                    it.addresses.any { getProperText(it.formattedAddress, shouldNormalize).contains(text, true) } ||
+                    it.IMs.any { it.data.contains(text, true) } ||
                     getProperText(it.notes, shouldNormalize).contains(text, true) ||
                     getProperText(it.organization.company, shouldNormalize).contains(text, true) ||
-                    getProperText(it.organization.jobPosition, shouldNormalize).contains(text, true) ||
-                    it.websites.any { it.contains(text, true) }
+                    getProperText(it.organization.jobTitle, shouldNormalize).contains(text, true) ||
+                    it.websites.any { it.URL.contains(text, true) }
             } as ArrayList
 
             filtered.sortBy {

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/FavoritesFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/fragments/FavoritesFragment.kt
@@ -189,9 +189,9 @@ class FavoritesFragment(context: Context, attributeSet: AttributeSet) : MyViewPa
 
     override fun onSearchQueryChanged(text: String) {
         val contacts = allContacts.filter {
-            it.name.contains(text, true) || it.doesContainPhoneNumber(text)
+            it.displayname.contains(text, true) || it.doesContainPhoneNumber(text)
         }.sortedByDescending {
-            it.name.startsWith(text, true)
+            it.displayname.startsWith(text, true)
         }.toMutableList() as ArrayList<Contact>
 
         fragment_placeholder.beVisibleIf(contacts.isEmpty())

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/RecentsHelper.kt
@@ -106,7 +106,7 @@ class RecentsHelper(private val context: Context) {
                                     }
                                 }
                                 false
-                            }?.name ?: number
+                            }?.displayname ?: number
                         }
                     }
                 }


### PR DESCRIPTION
I implemented the following changes:
.) All contact models now contain all the fields provided by Android ContactContract.
You previously only copied selected fields from the Android ContactContract to the internal Contact class and when writing back a modified contact those fields that were not part of the Contact class were deleted. I consider that very bad style, even if SimpleContact does not use these fields, other Contact management application or contact synchronisation tools might do so and simply deleting that information for no good reason seems bad to me.
.) The LocalContact has been expanded to match the Android ContactContract. Suitable converters from the previous data format have been added.
.) I also added comments to all contact classes explaining the connection to the Android ContactContract and the DAVCard format.
.) I added a structured address to the contact (in addition to the preformatted address), and implemented logic that will automatically update the preformatted address when the structured address changes (and the preformatted adresse was not previously modified by hand). The format of the preformatted address can be changed via localisation (but not yet be the target country of the address)
.) I added a formatted (full) name in addition to the structured name and implemented logic that automatically update the full name in a variety of (user selectable) formats.
.) I added phonetic names
.) I added support for multiple nicknames (optional - can be enabled/disabled in the Setting activity)
.) I added support for types of websites
.) I added support for types and protocols of instant messenger addresses (rather than abusing the type field to contain protocol information). I also added several modern IM applications to be predefined "custom" types.
.) I added support for relations (with support for the standard Android and vCard relation types as well as a wide range of custom types)
.) For item classes where multiple entries of one type are possible for one contact, you provide a '+' button to add additional items. Deleting unwanted items is usually accomplished by deleting the contents, but for events a '-' button is provided because the date can not be deleted. I added the option to provide a '-' button for all types of items, so that there is a consitency between creating items with a '+' button and deleting items with a '-' button. This feature can be enabled/disabled in the setting dialog (and is disabled by default).
.) When sharing a contact the user can (optionally) select which items of a contact shall be shared. Thus it is possible to store private/sensitive information in a contact and still share (the public part of) it.
.) When storing a contact back to the ContactContract, I prefer not to delete all old entries and rewrite them if the did not change. I check which components changed and only update these.
The code for updating and inserting an contact to the ContactContract has been unified. There used to be two functions for these two jobs, that were to a large extend duplicates of each other (but still needed to be maintained separatly). Now there is one unified routine.
.) When turning the mobile from landscape mode to portait mode while editing a contact the changes that were already made do no longer disappear. Even the current scroll position is maintained.
.) When changing the list of shown item cateories while editing a contact, the previously made changes are not lost.
.) When selecting the ringtone "Silence" in either the view or edit activity, the corresponding field is immediatly filled correctly with "Silence", not with "Unknown Ringtone" that is replaced with Silence only on the next time the activity is redrawn.
.) Pressing the 'Back' button while editing a contact checks if any changes have been made and presents a 'Save/Discard changes?' dialog as needed.
.) In the main activity, contacts that do not have e.g. a last name (assuming sorting by last name) now get a fastscroller entry of '*' at the end of the fastscoller list, rather than some a letter based on their (e.g.) first name that may or may not pop up at the end of the fastscroller (if it is not absorbed by another entry with the same letter).
 
Note: The above changes obviuously affect both Simple-Commons and Simple-Contacts quite a lot. There are also some minor changes to Simple-Dialer and Simple-Calendar, so these need to be merged to.
Please check out:
  https://github.com/rlieger/Simple-Commons/dev_add_complete_androidcontacts
  https://github.com/rlieger/Simple-Contacts/dev_add_complete_androidcontacts
  https://github.com/rlieger/Simple-Dialer/dev_add_complete_androidcontacts
  https://github.com/rlieger/Simple-Calendar/dev_add_complete_androidcontacts

Looking forward to your comments,
  Roland


