### PR TITLE
Update mute button state outside toggleMicrophone()

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/CallActivity.kt
@@ -444,6 +444,9 @@ class CallActivity : SimpleActivity() {
 
     private fun updateCallAudioState(route: AudioRoute?) {
         if (route != null) {
+            isMicrophoneOff = audioManager.isMicrophoneMute
+            updateMicrophoneButton()
+
             isSpeakerOn = route == AudioRoute.SPEAKER
             val supportedAudioRoutes = CallManager.getSupportedAudioRoutes()
             call_toggle_speaker.apply {
@@ -473,9 +476,13 @@ class CallActivity : SimpleActivity() {
 
     private fun toggleMicrophone() {
         isMicrophoneOff = !isMicrophoneOff
-        toggleButtonColor(call_toggle_microphone, isMicrophoneOff)
         audioManager.isMicrophoneMute = isMicrophoneOff
         CallManager.inCallService?.setMuted(isMicrophoneOff)
+        updateMicrophoneButton()
+    }
+
+    private fun updateMicrophoneButton() {
+        toggleButtonColor(call_toggle_microphone, isMicrophoneOff)
         call_toggle_microphone.contentDescription = getString(if (isMicrophoneOff) R.string.turn_microphone_on else R.string.turn_microphone_off)
     }
 


### PR DESCRIPTION
Fixes #63

I noticed that the speaker button state `isSpeakerOn` is loaded in `updateCallAudioState`, so I set `isMicrophoneOff` there too. Setting the button color/content description is also called in `updateCallAudioState`. Check #63 for bug replication steps; I tested and it worked in the emulator, even with two calls.

Please check that this is the right location for this change. I can make edits if needed.