### PR TITLE
Add dialpad_random_beeps feature

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/DialpadActivity.kt
@@ -374,7 +374,11 @@ class DialpadActivity : SimpleActivity() {
     private fun startDialpadTone(char: Char) {
         if (config.dialpadBeeps) {
             pressedKeys.add(char)
-            toneGeneratorHelper?.startTone(char)
+            if (config.dialpadRandomBeeps) {
+                toneGeneratorHelper?.startRandomTone()
+            } else {
+                toneGeneratorHelper?.startTone(char)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/activities/SettingsActivity.kt
@@ -80,6 +80,7 @@ class SettingsActivity : SimpleActivity() {
         setupDialpadVibrations()
         setupDialpadNumbers()
         setupDialpadBeeps()
+        setupDialpadRandomBeeps()
         setupShowCallConfirmation()
         setupDisableProximitySensor()
         setupDisableSwipeToAnswer()
@@ -276,9 +277,21 @@ class SettingsActivity : SimpleActivity() {
     private fun setupDialpadBeeps() {
         binding.apply {
             settingsDialpadBeeps.isChecked = config.dialpadBeeps
+            settingsDialpadRandomBeepsHolder.beVisibleIf(config.dialpadBeeps)
             settingsDialpadBeepsHolder.setOnClickListener {
                 settingsDialpadBeeps.toggle()
                 config.dialpadBeeps = settingsDialpadBeeps.isChecked
+                settingsDialpadRandomBeepsHolder.beVisibleIf(config.dialpadBeeps)
+            }
+        }
+    }
+
+    private fun setupDialpadRandomBeeps() {
+        binding.apply {
+            settingsDialpadRandomBeeps.isChecked = config.dialpadRandomBeeps
+            settingsDialpadRandomBeepsHolder.setOnClickListener {
+                settingsDialpadRandomBeeps.toggle()
+                config.dialpadRandomBeeps = settingsDialpadRandomBeeps.isChecked
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Config.kt
@@ -86,6 +86,10 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getBoolean(DIALPAD_BEEPS, true)
         set(dialpadBeeps) = prefs.edit().putBoolean(DIALPAD_BEEPS, dialpadBeeps).apply()
 
+    var dialpadRandomBeeps: Boolean
+        get() = prefs.getBoolean(DIALPAD_RANDOM_BEEPS, false)
+        set(dialpadRandomBeeps) = prefs.edit().putBoolean(DIALPAD_RANDOM_BEEPS, dialpadRandomBeeps).apply()
+
     var alwaysShowFullscreen: Boolean
         get() = prefs.getBoolean(ALWAYS_SHOW_FULLSCREEN, false)
         set(alwaysShowFullscreen) = prefs.edit().putBoolean(ALWAYS_SHOW_FULLSCREEN, alwaysShowFullscreen).apply()

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/Constants.kt
@@ -17,6 +17,7 @@ const val FAVORITES_CUSTOM_ORDER_SELECTED = "favorites_custom_order_selected"
 const val WAS_OVERLAY_SNACKBAR_CONFIRMED = "was_overlay_snackbar_confirmed"
 const val DIALPAD_VIBRATION = "dialpad_vibration"
 const val DIALPAD_BEEPS = "dialpad_beeps"
+const val DIALPAD_RANDOM_BEEPS = "dialpad_random_beeps"
 const val HIDE_DIALPAD_NUMBERS = "hide_dialpad_numbers"
 const val ALWAYS_SHOW_FULLSCREEN = "always_show_fullscreen"
 

--- a/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/dialer/helpers/ToneGeneratorHelper.kt
@@ -21,6 +21,10 @@ class ToneGeneratorHelper(context: Context, private val minToneLengthMs: Long) {
         return audioManager.ringerMode in arrayOf(AudioManager.RINGER_MODE_SILENT, AudioManager.RINGER_MODE_VIBRATE)
     }
 
+    fun startRandomTone() {
+        startTone(charToTone.values.random())
+    }
+
     fun startTone(char: Char) {
         toneStartTimeMs = System.currentTimeMillis()
         startTone(charToTone[char] ?: -1)

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -244,6 +244,21 @@
 
             </RelativeLayout>
 
+            <RelativeLayout
+                android:id="@+id/settings_dialpad_random_beeps_holder"
+                style="@style/SettingsHolderCheckboxStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                    android:id="@+id/settings_dialpad_random_beeps"
+                    style="@style/SettingsCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/dialpad_random_beeps" />
+
+            </RelativeLayout>
+
             <include
                 android:id="@+id/settings_general_settings_divider"
                 layout="@layout/divider" />

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">وسم</string>
     <string name="call_number">رقم الاتصال</string>
     <string name="dialpad_beeps">تمكين الصفير عند نقر أزرار لوحة الاتصال</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">تمكين الاهتزازات عند نقر أزرار لوحة الاتصال</string>
     <!-- Dialer -->
     <string name="dialer">الهاتف</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Call number</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">Dialer</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Рашотка</string>
     <string name="call_number">Нумар выкліку</string>
     <string name="dialpad_beeps">Уключыць гукавыя сігналы пры націсканні кнопак панэлі набору</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Уключыць вібрацыю пры націсканні кнопак панэлі набору</string>
     <!-- Dialer -->
     <string name="dialer">Тэлефон</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Диез</string>
     <string name="call_number">Номер</string>
     <string name="dialpad_beeps">Активиране на звукови сигнали при докосване на бутоните на клавиатурата за набиране</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Активиране на вибрации при докосване на бутоните на клавиатурата за набиране</string>
     <!-- Dialer -->
     <string name="dialer">Телефон</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Etiqueta</string>
     <string name="call_number">Número de trucada</string>
     <string name="dialpad_beeps">Activa els sons en fer clic als botons del teclat de marcatge</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Activa les vibracions en fer clic als botons del teclat de marcatge</string>
     <!-- Dialer -->
     <string name="dialer">Marcador</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Mřížka</string>
     <string name="call_number">Volané číslo</string>
     <string name="dialpad_beeps">Povolit pípání při kliknutí na tlačítka číselníku</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Povolit vibrace při kliknutí na tlačítka číselníku</string>
     <!-- Dialer -->
     <string name="dialer">Telefon</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Opkaldsnummer</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">Opkald</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Raute</string>
     <string name="call_number">Rufnummer</string>
     <string name="dialpad_beeps">Signaltöne bei Tastendruck auf das Wähltastenfeld</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Vibration bei Tastendruck auf das Wähltastenfeld</string>
     <!-- Dialer -->
     <string name="dialer">Telefon</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Ετικέτα</string>
     <string name="call_number">Αριθμός κλήσης</string>
     <string name="dialpad_beeps">Ενεργοποίηση ήχου στα αγγίγματα των κουμπιών του πληκτρολογίου κλήσης</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Ενεργοποίηση δονήσεων στα αγγίγματα των κουμπιών του πληκτρολογίου κλήσης</string>
     <!-- Dialer -->
     <string name="dialer">Κλήση</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Call number</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">Dialer</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Almohadilla</string>
     <string name="call_number">Número de llamada</string>
     <string name="dialpad_beeps">Activar los pitidos al pulsar los botones del teclado telefónico</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Activar las vibraciones al pulsar los botones del teclado</string>
     <!-- Dialer -->
     <string name="dialer">Marcador</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Teemaviide</string>
     <string name="call_number">Helista numbrile</string>
     <string name="dialpad_beeps">Numbriklahvistiku nupu klõpsamisel esita helisignaali</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Numbriklahvistiku nupu klõpsamisel värista telefoni</string>
     <!-- Dialer -->
     <string name="dialer">Telefon</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">مربع</string>
     <string name="call_number">شماره تماس</string>
     <string name="dialpad_beeps">فعال کردن صدا هنگام لمس دکمه‌های شماره‌گیر</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">فعال کردن لرزش هنگام لمس دکمه‌های شماره‌گیر</string>
     <!-- Dialer -->
     <string name="dialer">تلفن</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Ruutu</string>
     <string name="call_number">Soita numeroon</string>
     <string name="dialpad_beeps">Piippaa numeronäppäimistön painalluksista</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Värähdä numeronäppäimistön painalluksista</string>
     <!-- Dialer -->
     <string name="dialer">Puhelin</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Dièse</string>
     <string name="call_number">Numéro d\'appel</string>
     <string name="dialpad_beeps">Activer les sons lors de l\'appui sur les touches du pavé numérique</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Activer les vibrations lors de l\'appui sur les touches du pavé numérique</string>
     <!-- Dialer -->
     <string name="dialer">Pavé numérique</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Cancelo</string>
     <string name="call_number">Chamar a número</string>
     <string name="dialpad_beeps">Activa os sons o premer no botón do teclado</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Activa as vibracións o premer no botón do teclado de marcación</string>
     <!-- Dialer -->
     <string name="dialer">Marcador</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Taraba</string>
     <string name="call_number">Nazovi broj</string>
     <string name="dialpad_beeps">Aktiviraj zvučne signale prilikom pritiskanja gumbova brojčanika</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Aktiviraj vibriranje prilikom pritiskanja gumbova brojčanika</string>
     <!-- Dialer -->
     <string name="dialer">Birač</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Kettőskereszt</string>
     <string name="call_number">Hívószám</string>
     <string name="dialpad_beeps">Pittyegés a tárcsázógombokra történő kattintás során</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Rezgés a tárcsázógombokra történő kattintás során</string>
     <!-- Dialer -->
     <string name="dialer">Tárcsázó</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Pagar</string>
     <string name="call_number">Nomor telepon</string>
     <string name="dialpad_beeps">Aktifkan suara ketika tombol papan ditekan</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Aktifkan getaran ketika tombol papan ditekan</string>
     <!-- Dialer -->
     <string name="dialer">Dialer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Cancelletto</string>
     <string name="call_number">Numero di chiamata</string>
     <string name="dialpad_beeps">Abilita i segnali acustici ai clic dei pulsanti della tastiera</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Abilita le vibrazioni sui clic dei pulsanti della tastiera</string>
     <!-- Dialer -->
     <string name="dialer">Compositore</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">סולמית</string>
     <string name="call_number">מספר שיחה</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">חייגן</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">ハッシュタグ</string>
     <string name="call_number">電話番号</string>
     <string name="dialpad_beeps">ダイヤルパッドボタンのタップ時にビープ音を鳴らす</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">ダイヤルパッドボタンのタップ時に振動させる</string>
     <!-- Dialer -->
     <string name="dialer">電話</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Grotelėmis</string>
     <string name="call_number">Skambinti numeriu</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">Numerio rinkiklis</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Call number</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">ഡയലർ</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Emneknagg</string>
     <string name="call_number">Ring nummer</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">Oppringer</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Hekje</string>
     <string name="call_number">Nummer bellen</string>
     <string name="dialpad_beeps">Geluiden bij klikken op het toetsenblok inschakelen</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Trillen bij klikken op het toetsenblok</string>
     <!-- Dialer -->
     <string name="dialer">Telefoon</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -24,6 +24,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Call number</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
 
     <!-- Dialer -->

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">ہیش‌ٹیگ</string>
     <string name="call_number">کال دا نمبر</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">فون دائک</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Kratka</string>
     <string name="call_number">Zadzwoń na numer</string>
     <string name="dialpad_beeps">Włącz sygnały dźwiękowe przy naciśnięciach przycisków na panelu wybierania</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Włącz wibracje przy naciśnięciach przycisków na panelu wybierania</string>
     <!-- Dialer -->
     <string name="dialer">Telefon</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Numero de telefone</string>
     <string name="dialpad_beeps">Ativar sons do teclado</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Ativar vibrações do teclado</string>
     <!-- Dialer -->
     <string name="dialer">Discador</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">\'Hashtag\'</string>
     <string name="call_number">Ligar</string>
     <string name="dialpad_beeps">Ativar sons do teclado</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Ativar vibração do teclado</string>
     <!-- Dialer -->
     <string name="dialer">Marcador</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Apelaţi numărul</string>
     <string name="dialpad_beeps">Activați semnalele sonore la apăsarea butoanelor tastaturii telefonice</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Activați vibrațiile la apăsarea butoanelor tastaturii telefonice</string>
     <!-- Dialer -->
     <string name="dialer">Dialer</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Хэштег</string>
     <string name="call_number">Номер вызова</string>
     <string name="dialpad_beeps">Звуковые сигналы при нажатии кнопок набора номера</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Вибрация при нажатии кнопок набора номера</string>
     <!-- Dialer -->
     <string name="dialer">Телефон</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Mriežka</string>
     <string name="call_number">Zavolať číslo</string>
     <string name="dialpad_beeps">Povoliť pípanie pri stláčaní tlačidiel na číselníku</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Povoliť vibrácie pri stláčaní tlačidiel na číselníku</string>
     <!-- Dialer -->
     <string name="dialer">Telefón</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Lojtra</string>
     <string name="call_number">Pokliči številko</string>
     <string name="dialpad_beeps">Omogoči piske ob klikih gumbov na številčnici</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Omogoči vibriranje ob klikih gumbov na številčnici</string>
     <!-- Dialer -->
     <string name="dialer">Telefon</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Хаштег</string>
     <string name="call_number">Позив број</string>
     <string name="dialpad_beeps">Омогућите звучне сигнале при кликовима на дугме на тастатури</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Омогућите звучне сигнале при кликовима на дугме на тастатури</string>
     <!-- Dialer -->
     <string name="dialer">Диалер</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Fyrkant</string>
     <string name="call_number">Ring nummer</string>
     <string name="dialpad_beeps">Aktivera knappsatsljud</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Aktivera knappsatsvibration</string>
     <!-- Dialer -->
     <string name="dialer">Telefon</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Call number</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
     <!-- Dialer -->
     <string name="dialer">Dialer</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Kare işareti</string>
     <string name="call_number">Numarayı ara</string>
     <string name="dialpad_beeps">Tuş takımı düğmelerine tıklandığında bip sesini etkinleştir</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Tuş takımı düğmelerine tıklandığında titreşimi etkinleştir</string>
     <!-- Dialer -->
     <string name="dialer">Çevirici</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Хештег</string>
     <string name="call_number">Номер виклику</string>
     <string name="dialpad_beeps">Увімкнути звукові сигнали при наборі номеру</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Увімкнути вібрації при наборі номеру</string>
     <!-- Dialer -->
     <string name="dialer">Телефон</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">Dấu thăng</string>
     <string name="call_number">Số điện thoại</string>
     <string name="dialpad_beeps">Bật tiếng bíp khi bấm vào nút quay số</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Bật rung khi nhấp vào nút quay số</string>
     <!-- Dialer -->
     <string name="dialer">Trình quay số</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">标签</string>
     <string name="call_number">呼叫号码</string>
     <string name="dialpad_beeps">单击拨号盘按钮时发出哔哔声</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">单击拨号盘按钮时震动手机</string>
     <!-- Dialer -->
     <string name="dialer">拨号器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,6 +21,7 @@
     <string name="hashtag">井號</string>
     <string name="call_number">撥打電話號碼</string>
     <string name="dialpad_beeps">啟用撥號鍵盤按鈕點選的提示音</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">啟用撥號鍵盤按鈕點選的震動</string>
     <!-- Dialer -->
     <string name="dialer">撥號器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="hashtag">Hashtag</string>
     <string name="call_number">Call number</string>
     <string name="dialpad_beeps">Enable beeps on dialpad button clicks</string>
+    <string name="dialpad_random_beeps">Randomize beep tone on dialpad button clicks</string>
     <string name="dialpad_vibrations">Enable vibrations on dialpad button clicks</string>
 
     <!-- Dialer -->


### PR DESCRIPTION
Adds an option in settings to randomize the beep dialtone. 

This is so anyone listening to your call will not be able to determine which buttons you are pressing.

* Adds an option in settings, with default value of `false`
* Should only affect sound coming from the speaker, not the actual DTMF tone sent on the wire